### PR TITLE
cli: gracefully handle headless environments in setup flow

### DIFF
--- a/pkg/cli/setup/setup.go
+++ b/pkg/cli/setup/setup.go
@@ -2,8 +2,6 @@ package setup
 
 import (
 	"fmt"
-	"os"
-	"runtime"
 
 	"github.com/cli/browser"
 	log "github.com/sirupsen/logrus"
@@ -12,16 +10,6 @@ import (
 	"goauthentik.io/platform/pkg/ak"
 	"goauthentik.io/platform/vnd/oauth"
 )
-
-func isHeadless() bool {
-	// On Linux/Unix, check for DISPLAY or WAYLAND_DISPLAY
-	if runtime.GOOS == "linux" || runtime.GOOS == "freebsd" || runtime.GOOS == "openbsd" {
-		if os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == "" {
-			return true
-		}
-	}
-	return false
-}
 
 type Options struct {
 	ProfileName  string
@@ -45,21 +33,12 @@ func Setup(opts Options) (*config.ConfigV1Profile, error) {
 		ClientID: opts.ClientID,
 		Scopes:   []string{"openid", "profile", "email", "offline_access", "goauthentik.io/api"},
 		BrowseURL: func(s string) error {
-			printURL := func() {
+			if err := browser.OpenURL(s); err != nil {
 				fmt.Println("------------------------------------------------------------")
 				fmt.Println("")
 				fmt.Printf("      Open this URL in your browser: %s\n", s)
 				fmt.Println("")
 				fmt.Println("------------------------------------------------------------")
-			}
-
-			if isHeadless() {
-				printURL()
-				return nil
-			}
-
-			if err := browser.OpenURL(s); err != nil {
-				printURL()
 			}
 			return nil
 		},


### PR DESCRIPTION
Issue:

Before, the setup command would attempt to open a browser using  xdg-open on headless Linux systems, which would give confusing errors like "Failed to open display" and "no DISPLAY environment variable specified" while the command hung.

The fix is to detect headless environments by checking for DISPLAY or WAYLAND_DISPLAY env vars on Linux/FreeBSD/OpenBSD. Included last 2 for future-proofing. When running headless, the verification URL is printed directly without attempting to launch a browser, as it was doing before.

Validated as follows:

`ak config setup --authentik-url https://some-domain.net`

Directly downloaded using pkg.g.i instructions for linux, and using a binary built scp'd onto a linux server for testing