### PR TITLE
agent: fix firefox host native config

### DIFF
--- a/cmd/agent_local/package/macos/authentik Agent.app/Contents/Resources/browser-host-firefox.json
+++ b/cmd/agent_local/package/macos/authentik Agent.app/Contents/Resources/browser-host-firefox.json
@@ -3,7 +3,7 @@
     "description": "authentik Platform",
     "path": "/Applications/authentik Agent.app/Contents/MacOS/ak-browser-support",
     "type": "stdio",
-    "allowed_origins": [
+    "allowed_extensions": [
         "platform-browser-extension@goauthentik.io"
     ]
 }

--- a/cmd/agent_local/package/windows/browser-host-firefox.json
+++ b/cmd/agent_local/package/windows/browser-host-firefox.json
@@ -3,7 +3,7 @@
     "description": "authentik Platform",
     "path": "ak-browser-support.exe",
     "type": "stdio",
-    "allowed_origins": [
+    "allowed_extensions": [
         "platform-browser-extension@goauthentik.io"
     ]
 }

--- a/cmd/agent_system/package/linux/browser-host-firefox.json
+++ b/cmd/agent_system/package/linux/browser-host-firefox.json
@@ -3,7 +3,7 @@
     "description": "authentik Platform",
     "path": "/usr/bin/ak-browser-support",
     "type": "stdio",
-    "allowed_origins": [
+    "allowed_extensions": [
         "platform-browser-extension@goauthentik.io"
     ]
 }


### PR DESCRIPTION
Firefox doesn't use `allowed_origins` but rather `allowed_extensions`