### PR TITLE
 facts/os: avoid blank linux os.version on rolling releases

### DIFF
--- a/pkg/platform/facts/os/os_linux.go
+++ b/pkg/platform/facts/os/os_linux.go
@@ -15,23 +15,27 @@ import (
 func gather(ctx *common.GatherContext) (api.DeviceFactsRequestOs, error) {
 	name, version := getLinuxDistribution()
 
-	return api.DeviceFactsRequestOs{
-		Arch:    runtime.GOARCH,
-		Family:  api.DEVICEFACTSOSFAMILY_LINUX,
-		Name:    api.PtrString(name),
-		Version: api.PtrString(version),
-	}, nil
+	info := api.DeviceFactsRequestOs{
+		Arch:   runtime.GOARCH,
+		Family: api.DEVICEFACTSOSFAMILY_LINUX,
+		Name:   api.PtrString(name),
+	}
+	if version != "" {
+		info.Version = api.PtrString(version)
+	}
+
+	return info, nil
 }
 
 func getLinuxDistribution() (string, string) {
 	// Try /etc/os-release first (systemd standard)
-	if fullVersion := parseOSRelease("/etc/os-release"); fullVersion != "" {
-		return extractVersion(fullVersion)
+	if name, version := parseOSRelease("/etc/os-release"); name != "" {
+		return name, version
 	}
 
 	// Try /usr/lib/os-release as fallback
-	if fullVersion := parseOSRelease("/usr/lib/os-release"); fullVersion != "" {
-		return extractVersion(fullVersion)
+	if name, version := parseOSRelease("/usr/lib/os-release"); name != "" {
+		return name, version
 	}
 
 	// Try /etc/lsb-release (Ubuntu/Debian)
@@ -57,25 +61,62 @@ func getLinuxDistribution() (string, string) {
 	return "Linux", getKernelVersion()
 }
 
-func parseOSRelease(filename string) string {
+func parseOSRelease(filename string) (string, string) {
 	file, err := os.Open(filename)
 	if err != nil {
-		return ""
+		return "", ""
 	}
 	defer func() {
 		_ = file.Close()
 	}()
 
 	scanner := bufio.NewScanner(file)
+	var name, prettyName, versionID, version, buildID string
 
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if strings.HasPrefix(line, "PRETTY_NAME=") {
-			return strings.Trim(strings.TrimPrefix(line, "PRETTY_NAME="), "\"")
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		value = strings.Trim(value, "\"'")
+		switch key {
+		case "NAME":
+			name = value
+		case "PRETTY_NAME":
+			prettyName = value
+		case "VERSION_ID":
+			versionID = value
+		case "VERSION":
+			version = value
+		case "BUILD_ID":
+			buildID = value
 		}
 	}
 
-	return ""
+	fullName := prettyName
+	if fullName == "" {
+		fullName = name
+	}
+	if fullName == "" {
+		return "", ""
+	}
+
+	parsedName, parsedVersion := extractVersion(fullName)
+	if parsedVersion != "" {
+		return parsedName, parsedVersion
+	}
+	if versionID != "" {
+		return parsedName, versionID
+	}
+	if version != "" {
+		return parsedName, version
+	}
+	if buildID != "" {
+		return parsedName, buildID
+	}
+
+	return parsedName, ""
 }
 
 func parseLSBRelease() (string, string) {

--- a/pkg/platform/facts/os/os_test.go
+++ b/pkg/platform/facts/os/os_test.go
@@ -1,8 +1,11 @@
 package os
 
 import (
+	stdos "os"
+	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +21,9 @@ func TestGather(t *testing.T) {
 	assert.NotEqual(t, info.Family, "")
 	assert.True(t, slices.Contains(api.AllowedDeviceFactsOSFamilyEnumValues, info.Family))
 	assert.Equal(t, info.Arch, runtime.GOARCH)
-	assert.Regexp(t, `(\d+\.(?:\d+\.?)+)`, *info.Version, "Version must only contain numbers: '%s'", *info.Version)
+	if info.Version != nil {
+		assert.NotEqual(t, strings.TrimSpace(*info.Version), "")
+	}
 }
 
 func TestExtract(t *testing.T) {
@@ -41,6 +46,54 @@ func TestExtract(t *testing.T) {
 		t.Run(tc.raw, func(t *testing.T) {
 			name, version := extractVersion(tc.raw)
 			assert.Equal(t, tc.name, name)
+			assert.Equal(t, tc.version, version)
+		})
+	}
+}
+
+func TestParseOSRelease(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		osName  string
+		version string
+	}{
+		{
+			name: "pretty name with embedded version",
+			content: `NAME="Ubuntu"
+PRETTY_NAME="Ubuntu 24.04.3 LTS"
+`,
+			osName:  "Ubuntu",
+			version: "24.04.3 LTS",
+		},
+		{
+			name: "fallback to version id",
+			content: `NAME="TestOS"
+PRETTY_NAME="TestOS"
+VERSION_ID="1.2"
+VERSION="rolling"
+BUILD_ID="2025.03.19"
+`,
+			osName:  "TestOS",
+			version: "1.2",
+		},
+		{
+			name: "fallback to build id",
+			content: `NAME="EndeavourOS"
+PRETTY_NAME="EndeavourOS"
+BUILD_ID="2025.03.19"
+`,
+			osName:  "EndeavourOS",
+			version: "2025.03.19",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "os-release")
+			err := stdos.WriteFile(path, []byte(tc.content), 0o600)
+			assert.NoError(t, err)
+
+			name, version := parseOSRelease(path)
+			assert.Equal(t, tc.osName, name)
 			assert.Equal(t, tc.version, version)
 		})
 	}


### PR DESCRIPTION
```
INFO[1802] Starting user/group fetch                     logger=component.directory pid=999545 target=ak-sysd
DEBU[1802] dispatching event                             id=directory logger=sysd pid=999545 target=ak-sysd topic=sysd.directory.fetched
DEBU[1802] dispatching event                             logger=sysd pid=999545 target=ak-sysd topic=sysd.directory.fetched
INFO[1802] Finished user/group fetch                     logger=component.directory next=30m0s pid=999545 target=ak-sysd
DEBU[1829] Starting facts gathering...                   logger=component.device pid=999545 target=ak-sysd
DEBU[1829] Gathering...                                  area=disk logger=component.device pid=999545 target=ak-sysd
DEBU[1829] Gathering...                                  area=hardware logger=component.device pid=999545 target=ak-sysd
DEBU[1829] Gathering...                                  area=network logger=component.device pid=999545 target=ak-sysd
DEBU[1829] Gathering...                                  area=os logger=component.device pid=999545 target=ak-sysd
DEBU[1829] Gathering...                                  area=process logger=component.device pid=999545 target=ak-sysd
DEBU[1829] Gathering...                                  area=user logger=component.device pid=999545 target=ak-sysd
DEBU[1829] Gathering...                                  area=group logger=component.device pid=999545 target=ak-sysd
DEBU[1829] Gathering...                                  area=vendor logger=component.device pid=999545 target=ak-sysd
DEBU[1829] Finished facts gathering                      logger=component.device pid=999545 target=ak-sysd
WARN[1829] failed to checkin                             error="failed to checkin: HTTP Error '400 Bad Request' during request 'POST /api/v3/endpoints/agents/connectors/check_in/': \"{\"os\":{\"version\":[\"This field may not be blank.\"]}}\" (Request ID 'ec97fc27c5b34fafbaee4f123b6d1c34')" logger=component.device pid=999545 target=ak-sysd
DEBU[1831] Starting a new transaction [writable: false]  logger=storage.state
DEBU[1831] Starting a new transaction [writable: false] successfully  logger=storage.state
```
According to [os-release(5)](https://www.freedesktop.org/software/systemd/man/254/os-release.html?__goaway_challenge=meta-refresh&__goaway_id=d8d6550822849863b8c865ad0d75552b)

PRETTY_NAME=

A pretty operating system name in a format suitable for presentation to the user. **_May or may not contain a release code name or OS version of some kind_**, as suitable. If not set, a default of "PRETTY_NAME="Linux"" may be used

So, version is not guaranteed to be present in PRETTY_NAME, and parsing a version from it can legitimately result in an empty value on rolling-release distributions.

This means that the entire check-in request is rejected because os.version is present but blank

The endpoint requires a value if version is sent, so the agent should either:
- send a valid version
- omit version entirely when no value can be derived, since the field i optional


