### PR TITLE
agent_local: close SysdClient connection after addSysd ping

### DIFF
--- a/pkg/agent_local/tray/items.go
+++ b/pkg/agent_local/tray/items.go
@@ -80,6 +80,9 @@ func (t *Tray) addSysd() {
 		t.log.WithError(err).Warning("failed to ping sysd")
 		return
 	}
+	defer func() {
+		_ = sysc.Close()
+	}()
 	pr, err := sysc.Ping(t.ctx, &emptypb.Empty{})
 	if err != nil {
 		t.log.WithError(err).Warning("failed to ping sysd")


### PR DESCRIPTION
addSysd is called every 30 seconds from the systray update ticker. Without closing the connection, a new grpc.ClientConn was leaked on every call.