### PR TITLE
pkg/ak: close HTTP response body after token renewal

### DIFF
--- a/pkg/ak/token/token_profile_renew.go
+++ b/pkg/ak/token/token_profile_renew.go
@@ -39,6 +39,9 @@ func (ptm *ProfileTokenManager) renew() error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		_ = res.Body.Close()
+	}()
 	b, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err


### PR DESCRIPTION
Not closing the body prevented the underlying TCP connection from returning to the transport pool, leaking a connection on each renewal.