### PR TITLE
agent_local: stop periodic update ticker and goroutine on Quit

### DIFF
--- a/pkg/agent_local/tray/tray.go
+++ b/pkg/agent_local/tray/tray.go
@@ -53,9 +53,16 @@ func (t *Tray) Start() {
 		t.systrayConfigUpdate()
 	})
 	go func() {
-		for range time.NewTicker(30 * time.Second).C {
-			t.log.Debug("Updating systray")
-			t.systrayConfigUpdate()
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				t.log.Debug("Updating systray")
+				t.systrayConfigUpdate()
+			case <-t.Exit:
+				return
+			}
 		}
 	}()
 	systray.Run(t.systrayReady, func() {


### PR DESCRIPTION
The ticker's reference was previously discarded and the goroutine had no exit path, leaking both resources when the tray shut down. A stopCh is now closed by Quit() to signal the goroutine to return and stop the ticker.