### PR TITLE
sysd: switch caps to ping server

### DIFF
--- a/ee/psso/Bridge/Generated/ping.grpc.swift
+++ b/ee/psso/Bridge/Generated/ping.grpc.swift
@@ -34,9 +34,23 @@ internal enum Ping: Sendable {
                 type: .unary
             )
         }
+        /// Namespace for "Capabilities" metadata.
+        internal enum Capabilities: Sendable {
+            /// Request type for "Capabilities".
+            internal typealias Input = SwiftProtobuf.Google_Protobuf_Empty
+            /// Response type for "Capabilities".
+            internal typealias Output = CapabilitiesResponse
+            /// Descriptor for "Capabilities".
+            internal static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "ping.Ping"),
+                method: "Capabilities",
+                type: .unary
+            )
+        }
         /// Descriptors for all methods in the "ping.Ping" service.
         internal static let descriptors: [GRPCCore.MethodDescriptor] = [
-            Ping.descriptor
+            Ping.descriptor,
+            Capabilities.descriptor
         ]
     }
 }
@@ -73,6 +87,25 @@ extension Ping {
             deserializer: some GRPCCore.MessageDeserializer<PingResponse>,
             options: GRPCCore.CallOptions,
             onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<PingResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "Capabilities" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `SwiftProtobuf.Google_Protobuf_Empty` message.
+        ///   - serializer: A serializer for `SwiftProtobuf.Google_Protobuf_Empty` messages.
+        ///   - deserializer: A deserializer for `CapabilitiesResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func capabilities<Result>(
+            request: GRPCCore.ClientRequest<SwiftProtobuf.Google_Protobuf_Empty>,
+            serializer: some GRPCCore.MessageSerializer<SwiftProtobuf.Google_Protobuf_Empty>,
+            deserializer: some GRPCCore.MessageDeserializer<CapabilitiesResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<CapabilitiesResponse>) async throws -> Result
         ) async throws -> Result where Result: Sendable
     }
 
@@ -121,6 +154,36 @@ extension Ping {
                 onResponse: handleResponse
             )
         }
+
+        /// Call the "Capabilities" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `SwiftProtobuf.Google_Protobuf_Empty` message.
+        ///   - serializer: A serializer for `SwiftProtobuf.Google_Protobuf_Empty` messages.
+        ///   - deserializer: A deserializer for `CapabilitiesResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        internal func capabilities<Result>(
+            request: GRPCCore.ClientRequest<SwiftProtobuf.Google_Protobuf_Empty>,
+            serializer: some GRPCCore.MessageSerializer<SwiftProtobuf.Google_Protobuf_Empty>,
+            deserializer: some GRPCCore.MessageDeserializer<CapabilitiesResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<CapabilitiesResponse>) async throws -> Result = { response in
+                try response.message
+            }
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.unary(
+                request: request,
+                descriptor: Ping.Method.Capabilities.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
     }
 }
 
@@ -147,6 +210,31 @@ extension Ping.ClientProtocol {
             request: request,
             serializer: GRPCProtobuf.ProtobufSerializer<SwiftProtobuf.Google_Protobuf_Empty>(),
             deserializer: GRPCProtobuf.ProtobufDeserializer<PingResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "Capabilities" method.
+    ///
+    /// - Parameters:
+    ///   - request: A request containing a single `SwiftProtobuf.Google_Protobuf_Empty` message.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    internal func capabilities<Result>(
+        request: GRPCCore.ClientRequest<SwiftProtobuf.Google_Protobuf_Empty>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<CapabilitiesResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        try await self.capabilities(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<SwiftProtobuf.Google_Protobuf_Empty>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<CapabilitiesResponse>(),
             options: options,
             onResponse: handleResponse
         )
@@ -179,6 +267,35 @@ extension Ping.ClientProtocol {
             metadata: metadata
         )
         return try await self.ping(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "Capabilities" method.
+    ///
+    /// - Parameters:
+    ///   - message: request message to send.
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    internal func capabilities<Result>(
+        _ message: SwiftProtobuf.Google_Protobuf_Empty,
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<CapabilitiesResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.ClientRequest<SwiftProtobuf.Google_Protobuf_Empty>(
+            message: message,
+            metadata: metadata
+        )
+        return try await self.capabilities(
             request: request,
             options: options,
             onResponse: handleResponse

--- a/ee/psso/Bridge/Generated/ping.pb.swift
+++ b/ee/psso/Bridge/Generated/ping.pb.swift
@@ -34,6 +34,60 @@ nonisolated struct PingResponse: Sendable {
   init() {}
 }
 
+nonisolated struct CapabilitiesResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var capabilities: [CapabilitiesResponse.Capability] = []
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  nonisolated enum Capability: SwiftProtobuf.Enum, Swift.CaseIterable {
+    typealias RawValue = Int
+    case unspecified // = 0
+    case authInteractive // = 1
+    case authAuthz // = 2
+    case debug // = 3
+    case UNRECOGNIZED(Int)
+
+    init() {
+      self = .unspecified
+    }
+
+    init?(rawValue: Int) {
+      switch rawValue {
+      case 0: self = .unspecified
+      case 1: self = .authInteractive
+      case 2: self = .authAuthz
+      case 3: self = .debug
+      default: self = .UNRECOGNIZED(rawValue)
+      }
+    }
+
+    var rawValue: Int {
+      switch self {
+      case .unspecified: return 0
+      case .authInteractive: return 1
+      case .authAuthz: return 2
+      case .debug: return 3
+      case .UNRECOGNIZED(let i): return i
+      }
+    }
+
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    static let allCases: [CapabilitiesResponse.Capability] = [
+      .unspecified,
+      .authInteractive,
+      .authAuthz,
+      .debug,
+    ]
+
+  }
+
+  init() {}
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate nonisolated let _protobuf_package = "ping"
@@ -71,4 +125,38 @@ nonisolated extension PingResponse: SwiftProtobuf.Message, SwiftProtobuf._Messag
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
+}
+
+nonisolated extension CapabilitiesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".CapabilitiesResponse"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}capabilities\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedEnumField(value: &self.capabilities) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.capabilities.isEmpty {
+      try visitor.visitPackedEnumField(value: self.capabilities, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: CapabilitiesResponse, rhs: CapabilitiesResponse) -> Bool {
+    if lhs.capabilities != rhs.capabilities {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension CapabilitiesResponse.Capability: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNSPECIFIED\0\u{1}AUTH_INTERACTIVE\0\u{1}AUTH_AUTHZ\0\u{1}DEBUG\0")
 }

--- a/ee/psso/Bridge/Generated/sys_ctrl.grpc.swift
+++ b/ee/psso/Bridge/Generated/sys_ctrl.grpc.swift
@@ -73,26 +73,12 @@ internal enum SystemCtrl: Sendable {
                 type: .unary
             )
         }
-        /// Namespace for "Capabilities" metadata.
-        internal enum Capabilities: Sendable {
-            /// Request type for "Capabilities".
-            internal typealias Input = SwiftProtobuf.Google_Protobuf_Empty
-            /// Response type for "Capabilities".
-            internal typealias Output = CapabilitiesResponse
-            /// Descriptor for "Capabilities".
-            internal static let descriptor = GRPCCore.MethodDescriptor(
-                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "sys_ctrl.SystemCtrl"),
-                method: "Capabilities",
-                type: .unary
-            )
-        }
         /// Descriptors for all methods in the "sys_ctrl.SystemCtrl" service.
         internal static let descriptors: [GRPCCore.MethodDescriptor] = [
             DomainList.descriptor,
             DomainEnroll.descriptor,
             DomainUnenroll.descriptor,
-            TroubleshootInspect.descriptor,
-            Capabilities.descriptor
+            TroubleshootInspect.descriptor
         ]
     }
 }
@@ -186,25 +172,6 @@ extension SystemCtrl {
             deserializer: some GRPCCore.MessageDeserializer<TroubleshootInspectResponse>,
             options: GRPCCore.CallOptions,
             onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<TroubleshootInspectResponse>) async throws -> Result
-        ) async throws -> Result where Result: Sendable
-
-        /// Call the "Capabilities" method.
-        ///
-        /// - Parameters:
-        ///   - request: A request containing a single `SwiftProtobuf.Google_Protobuf_Empty` message.
-        ///   - serializer: A serializer for `SwiftProtobuf.Google_Protobuf_Empty` messages.
-        ///   - deserializer: A deserializer for `CapabilitiesResponse` messages.
-        ///   - options: Options to apply to this RPC.
-        ///   - handleResponse: A closure which handles the response, the result of which is
-        ///       returned to the caller. Returning from the closure will cancel the RPC if it
-        ///       hasn't already finished.
-        /// - Returns: The result of `handleResponse`.
-        func capabilities<Result>(
-            request: GRPCCore.ClientRequest<SwiftProtobuf.Google_Protobuf_Empty>,
-            serializer: some GRPCCore.MessageSerializer<SwiftProtobuf.Google_Protobuf_Empty>,
-            deserializer: some GRPCCore.MessageDeserializer<CapabilitiesResponse>,
-            options: GRPCCore.CallOptions,
-            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<CapabilitiesResponse>) async throws -> Result
         ) async throws -> Result where Result: Sendable
     }
 
@@ -343,36 +310,6 @@ extension SystemCtrl {
                 onResponse: handleResponse
             )
         }
-
-        /// Call the "Capabilities" method.
-        ///
-        /// - Parameters:
-        ///   - request: A request containing a single `SwiftProtobuf.Google_Protobuf_Empty` message.
-        ///   - serializer: A serializer for `SwiftProtobuf.Google_Protobuf_Empty` messages.
-        ///   - deserializer: A deserializer for `CapabilitiesResponse` messages.
-        ///   - options: Options to apply to this RPC.
-        ///   - handleResponse: A closure which handles the response, the result of which is
-        ///       returned to the caller. Returning from the closure will cancel the RPC if it
-        ///       hasn't already finished.
-        /// - Returns: The result of `handleResponse`.
-        internal func capabilities<Result>(
-            request: GRPCCore.ClientRequest<SwiftProtobuf.Google_Protobuf_Empty>,
-            serializer: some GRPCCore.MessageSerializer<SwiftProtobuf.Google_Protobuf_Empty>,
-            deserializer: some GRPCCore.MessageDeserializer<CapabilitiesResponse>,
-            options: GRPCCore.CallOptions = .defaults,
-            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<CapabilitiesResponse>) async throws -> Result = { response in
-                try response.message
-            }
-        ) async throws -> Result where Result: Sendable {
-            try await self.client.unary(
-                request: request,
-                descriptor: SystemCtrl.Method.Capabilities.descriptor,
-                serializer: serializer,
-                deserializer: deserializer,
-                options: options,
-                onResponse: handleResponse
-            )
-        }
     }
 }
 
@@ -474,31 +411,6 @@ extension SystemCtrl.ClientProtocol {
             request: request,
             serializer: GRPCProtobuf.ProtobufSerializer<SwiftProtobuf.Google_Protobuf_Empty>(),
             deserializer: GRPCProtobuf.ProtobufDeserializer<TroubleshootInspectResponse>(),
-            options: options,
-            onResponse: handleResponse
-        )
-    }
-
-    /// Call the "Capabilities" method.
-    ///
-    /// - Parameters:
-    ///   - request: A request containing a single `SwiftProtobuf.Google_Protobuf_Empty` message.
-    ///   - options: Options to apply to this RPC.
-    ///   - handleResponse: A closure which handles the response, the result of which is
-    ///       returned to the caller. Returning from the closure will cancel the RPC if it
-    ///       hasn't already finished.
-    /// - Returns: The result of `handleResponse`.
-    internal func capabilities<Result>(
-        request: GRPCCore.ClientRequest<SwiftProtobuf.Google_Protobuf_Empty>,
-        options: GRPCCore.CallOptions = .defaults,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<CapabilitiesResponse>) async throws -> Result = { response in
-            try response.message
-        }
-    ) async throws -> Result where Result: Sendable {
-        try await self.capabilities(
-            request: request,
-            serializer: GRPCProtobuf.ProtobufSerializer<SwiftProtobuf.Google_Protobuf_Empty>(),
-            deserializer: GRPCProtobuf.ProtobufDeserializer<CapabilitiesResponse>(),
             options: options,
             onResponse: handleResponse
         )
@@ -618,35 +530,6 @@ extension SystemCtrl.ClientProtocol {
             metadata: metadata
         )
         return try await self.troubleshootInspect(
-            request: request,
-            options: options,
-            onResponse: handleResponse
-        )
-    }
-
-    /// Call the "Capabilities" method.
-    ///
-    /// - Parameters:
-    ///   - message: request message to send.
-    ///   - metadata: Additional metadata to send, defaults to empty.
-    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
-    ///   - handleResponse: A closure which handles the response, the result of which is
-    ///       returned to the caller. Returning from the closure will cancel the RPC if it
-    ///       hasn't already finished.
-    /// - Returns: The result of `handleResponse`.
-    internal func capabilities<Result>(
-        _ message: SwiftProtobuf.Google_Protobuf_Empty,
-        metadata: GRPCCore.Metadata = [:],
-        options: GRPCCore.CallOptions = .defaults,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<CapabilitiesResponse>) async throws -> Result = { response in
-            try response.message
-        }
-    ) async throws -> Result where Result: Sendable {
-        let request = GRPCCore.ClientRequest<SwiftProtobuf.Google_Protobuf_Empty>(
-            message: message,
-            metadata: metadata
-        )
-        return try await self.capabilities(
             request: request,
             options: options,
             onResponse: handleResponse

--- a/ee/psso/Bridge/Generated/sys_ctrl.pb.swift
+++ b/ee/psso/Bridge/Generated/sys_ctrl.pb.swift
@@ -88,60 +88,6 @@ nonisolated struct TroubleshootInspectResponse: Sendable {
   init() {}
 }
 
-nonisolated struct CapabilitiesResponse: Sendable {
-  // SwiftProtobuf.Message conformance is added in an extension below. See the
-  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
-  // methods supported on all messages.
-
-  var capabilities: [CapabilitiesResponse.Capability] = []
-
-  var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  nonisolated enum Capability: SwiftProtobuf.Enum, Swift.CaseIterable {
-    typealias RawValue = Int
-    case unspecified // = 0
-    case authInteractive // = 1
-    case authAuthz // = 2
-    case debug // = 3
-    case UNRECOGNIZED(Int)
-
-    init() {
-      self = .unspecified
-    }
-
-    init?(rawValue: Int) {
-      switch rawValue {
-      case 0: self = .unspecified
-      case 1: self = .authInteractive
-      case 2: self = .authAuthz
-      case 3: self = .debug
-      default: self = .UNRECOGNIZED(rawValue)
-      }
-    }
-
-    var rawValue: Int {
-      switch self {
-      case .unspecified: return 0
-      case .authInteractive: return 1
-      case .authAuthz: return 2
-      case .debug: return 3
-      case .UNRECOGNIZED(let i): return i
-      }
-    }
-
-    // The compiler won't synthesize support with the UNRECOGNIZED case.
-    static let allCases: [CapabilitiesResponse.Capability] = [
-      .unspecified,
-      .authInteractive,
-      .authAuthz,
-      .debug,
-    ]
-
-  }
-
-  init() {}
-}
-
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate nonisolated let _protobuf_package = "sys_ctrl"
@@ -314,38 +260,4 @@ nonisolated extension TroubleshootInspectResponse: SwiftProtobuf.Message, SwiftP
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
-}
-
-nonisolated extension CapabilitiesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  static let protoMessageName: String = _protobuf_package + ".CapabilitiesResponse"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}capabilities\0")
-
-  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeRepeatedEnumField(value: &self.capabilities) }()
-      default: break
-      }
-    }
-  }
-
-  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.capabilities.isEmpty {
-      try visitor.visitPackedEnumField(value: self.capabilities, fieldNumber: 1)
-    }
-    try unknownFields.traverse(visitor: &visitor)
-  }
-
-  static func ==(lhs: CapabilitiesResponse, rhs: CapabilitiesResponse) -> Bool {
-    if lhs.capabilities != rhs.capabilities {return false}
-    if lhs.unknownFields != rhs.unknownFields {return false}
-    return true
-  }
-}
-
-nonisolated extension CapabilitiesResponse.Capability: SwiftProtobuf._ProtoNameProviding {
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNSPECIFIED\0\u{1}AUTH_INTERACTIVE\0\u{1}AUTH_AUTHZ\0\u{1}DEBUG\0")
 }

--- a/ee/psso/Bridge/SysdBridge.swift
+++ b/ee/psso/Bridge/SysdBridge.swift
@@ -121,7 +121,7 @@ public class SysdBridge {
     }
 
     public func interactiveAuthSupported() async throws -> Bool {
-        return try await self.withClient(id: .ctrlSocket) { client in
+        return try await self.withClient { client in
             let c = SystemCtrl.Client(wrapping: client)
             let reply = try await c.capabilities(
                 request: ClientRequest(message: Google_Protobuf_Empty())

--- a/ee/psso/Bridge/SysdBridge.swift
+++ b/ee/psso/Bridge/SysdBridge.swift
@@ -122,7 +122,7 @@ public class SysdBridge {
 
     public func interactiveAuthSupported() async throws -> Bool {
         return try await self.withClient { client in
-            let c = SystemCtrl.Client(wrapping: client)
+            let c = Ping.Client(wrapping: client)
             let reply = try await c.capabilities(
                 request: ClientRequest(message: Google_Protobuf_Empty())
             )

--- a/pam/src/auth.rs
+++ b/pam/src/auth.rs
@@ -95,7 +95,10 @@ pub fn authenticate_impl(
 
     if password.starts_with(PW_PREFIX) {
         log::debug!("Token authentication");
-        let raw_token = password.strip_prefix(PW_PREFIX).unwrap_or(password).to_string();
+        let raw_token = password
+            .strip_prefix(PW_PREFIX)
+            .unwrap_or(password)
+            .to_string();
         let decoded = match decode_pb::<SshTokenAuthentication>(raw_token) {
             Ok(t) => t,
             Err(e) => {

--- a/pkg/agent_system/auth/interactive.go
+++ b/pkg/agent_system/auth/interactive.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gorilla/securecookie"
 	"goauthentik.io/platform/pkg/agent_system/component"
-	"goauthentik.io/platform/pkg/agent_system/ctrl"
+	"goauthentik.io/platform/pkg/agent_system/ping"
 	"goauthentik.io/platform/pkg/ak/flow"
 	"goauthentik.io/platform/pkg/pb"
 	"google.golang.org/grpc/codes"
@@ -15,11 +15,11 @@ import (
 )
 
 func (auth *Server) InteractiveAuth(ctx context.Context, req *pb.InteractiveAuthRequest) (*pb.InteractiveChallenge, error) {
-	ctrl, err := component.Get[*ctrl.Server](auth.ctx, ctrl.ID)
+	ping, err := component.Get[*ping.Server](auth.ctx, ping.ID)
 	if err != nil {
 		return nil, err
 	}
-	if !ctrl.InteractiveSupported() {
+	if !ping.InteractiveSupported() {
 		return nil, status.Error(codes.Unavailable, "Interactive authentication not available")
 	}
 	var ch *pb.InteractiveChallenge

--- a/pkg/agent_system/auth/interactive_async.go
+++ b/pkg/agent_system/auth/interactive_async.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"goauthentik.io/platform/pkg/agent_system/component"
 	"goauthentik.io/platform/pkg/agent_system/config"
-	"goauthentik.io/platform/pkg/agent_system/ctrl"
+	"goauthentik.io/platform/pkg/agent_system/ping"
 	"goauthentik.io/platform/pkg/ak"
 	"goauthentik.io/platform/pkg/pb"
 	"google.golang.org/grpc/codes"
@@ -23,11 +23,11 @@ func DeviceTokenHash(dom *config.DomainConfig) string {
 }
 
 func (auth *Server) InteractiveAuthAsync(ctx context.Context, _ *emptypb.Empty) (*pb.InteractiveAuthAsyncResponse, error) {
-	ctrl, err := component.Get[*ctrl.Server](auth.ctx, ctrl.ID)
+	ping, err := component.Get[*ping.Server](auth.ctx, ping.ID)
 	if err != nil {
 		return nil, err
 	}
-	if !ctrl.InteractiveSupported() {
+	if !ping.InteractiveSupported() {
 		return nil, status.Error(codes.Unavailable, "Interactive authentication not available")
 	}
 

--- a/pkg/agent_system/auth/interactive_test.go
+++ b/pkg/agent_system/auth/interactive_test.go
@@ -13,7 +13,7 @@ import (
 	"goauthentik.io/api/v3"
 	"goauthentik.io/platform/pkg/agent_system/component"
 	"goauthentik.io/platform/pkg/agent_system/config"
-	"goauthentik.io/platform/pkg/agent_system/ctrl"
+	"goauthentik.io/platform/pkg/agent_system/ping"
 	"goauthentik.io/platform/pkg/agent_system/session"
 	"goauthentik.io/platform/pkg/ak"
 	"goauthentik.io/platform/pkg/pb"
@@ -30,9 +30,9 @@ func testAuth(t *testing.T, dc *config.DomainConfig) Server {
 	assert.NoError(t, err)
 	ctx.Registry().(component.TestRegistry).Comp[session.ID] = sm
 
-	cm, err := ctrl.NewServer(ctx)
+	cm, err := ping.NewServer(ctx)
 	assert.NoError(t, err)
-	ctx.Registry().(component.TestRegistry).Comp[ctrl.ID] = cm
+	ctx.Registry().(component.TestRegistry).Comp[ping.ID] = cm
 
 	return Server{
 		log:  log.WithField("component", "test"),

--- a/pkg/agent_system/ping/caps.go
+++ b/pkg/agent_system/ping/caps.go
@@ -1,4 +1,4 @@
-package ctrl
+package ping
 
 import (
 	"context"
@@ -9,10 +9,10 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-func (ctrl *Server) InteractiveSupported() bool {
-	_, dom, err := ctrl.ctx.DomainAPI()
+func (ping *Server) InteractiveSupported() bool {
+	_, dom, err := ping.ctx.DomainAPI()
 	if err != nil {
-		ctrl.log.WithError(err).Warning("failed to get domain API")
+		ping.ctx.Log().WithError(err).Warning("failed to get domain API")
 		return false
 	}
 	lic := dom.Config().LicenseStatus
@@ -22,9 +22,9 @@ func (ctrl *Server) InteractiveSupported() bool {
 	return *lic.Get() != api.LICENSESTATUSENUM_UNLICENSED
 }
 
-func (ctrl *Server) Capabilities(context.Context, *emptypb.Empty) (*pb.CapabilitiesResponse, error) {
+func (ping *Server) Capabilities(context.Context, *emptypb.Empty) (*pb.CapabilitiesResponse, error) {
 	caps := []pb.CapabilitiesResponse_Capability{}
-	if ctrl.InteractiveSupported() {
+	if ping.InteractiveSupported() {
 		caps = append(caps, pb.CapabilitiesResponse_AUTH_INTERACTIVE)
 	}
 	if config.Manager().Get().Debug {

--- a/pkg/agent_system/ping/ping.go
+++ b/pkg/agent_system/ping/ping.go
@@ -15,29 +15,33 @@ const ID = "ping"
 
 type Server struct {
 	pb.UnimplementedPingServer
+
+	ctx component.Context
 }
 
 func NewServer(ctx component.Context) (component.Component, error) {
-	srv := &Server{}
+	srv := &Server{
+		ctx: ctx,
+	}
 	return srv, nil
 }
 
-func (ps *Server) Start() error {
+func (ping *Server) Start() error {
 	return nil
 }
 
-func (ps *Server) Stop() error {
+func (ping *Server) Stop() error {
 	return nil
 }
 
-func (ps *Server) RegisterForID(id string, s grpc.ServiceRegistrar) {
+func (ping *Server) RegisterForID(id string, s grpc.ServiceRegistrar) {
 	if id != types.SocketIDDefault {
 		return
 	}
-	pb.RegisterPingServer(s, ps)
+	pb.RegisterPingServer(s, ping)
 }
 
-func (ps *Server) Ping(context.Context, *emptypb.Empty) (*pb.PingResponse, error) {
+func (ping *Server) Ping(context.Context, *emptypb.Empty) (*pb.PingResponse, error) {
 	return &pb.PingResponse{
 		Component: "sysd",
 		Version:   meta.FullVersion(),

--- a/pkg/pb/ping.pb.go
+++ b/pkg/pb/ping.pb.go
@@ -22,6 +22,58 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type CapabilitiesResponse_Capability int32
+
+const (
+	CapabilitiesResponse_UNSPECIFIED      CapabilitiesResponse_Capability = 0
+	CapabilitiesResponse_AUTH_INTERACTIVE CapabilitiesResponse_Capability = 1
+	CapabilitiesResponse_AUTH_AUTHZ       CapabilitiesResponse_Capability = 2
+	CapabilitiesResponse_DEBUG            CapabilitiesResponse_Capability = 3
+)
+
+// Enum value maps for CapabilitiesResponse_Capability.
+var (
+	CapabilitiesResponse_Capability_name = map[int32]string{
+		0: "UNSPECIFIED",
+		1: "AUTH_INTERACTIVE",
+		2: "AUTH_AUTHZ",
+		3: "DEBUG",
+	}
+	CapabilitiesResponse_Capability_value = map[string]int32{
+		"UNSPECIFIED":      0,
+		"AUTH_INTERACTIVE": 1,
+		"AUTH_AUTHZ":       2,
+		"DEBUG":            3,
+	}
+)
+
+func (x CapabilitiesResponse_Capability) Enum() *CapabilitiesResponse_Capability {
+	p := new(CapabilitiesResponse_Capability)
+	*p = x
+	return p
+}
+
+func (x CapabilitiesResponse_Capability) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CapabilitiesResponse_Capability) Descriptor() protoreflect.EnumDescriptor {
+	return file_ping_proto_enumTypes[0].Descriptor()
+}
+
+func (CapabilitiesResponse_Capability) Type() protoreflect.EnumType {
+	return &file_ping_proto_enumTypes[0]
+}
+
+func (x CapabilitiesResponse_Capability) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CapabilitiesResponse_Capability.Descriptor instead.
+func (CapabilitiesResponse_Capability) EnumDescriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{1, 0}
+}
+
 type PingResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Component     string                 `protobuf:"bytes,1,opt,name=component,proto3" json:"component,omitempty"`
@@ -74,6 +126,50 @@ func (x *PingResponse) GetVersion() string {
 	return ""
 }
 
+type CapabilitiesResponse struct {
+	state         protoimpl.MessageState            `protogen:"open.v1"`
+	Capabilities  []CapabilitiesResponse_Capability `protobuf:"varint,1,rep,packed,name=capabilities,proto3,enum=ping.CapabilitiesResponse_Capability" json:"capabilities,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CapabilitiesResponse) Reset() {
+	*x = CapabilitiesResponse{}
+	mi := &file_ping_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CapabilitiesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CapabilitiesResponse) ProtoMessage() {}
+
+func (x *CapabilitiesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CapabilitiesResponse.ProtoReflect.Descriptor instead.
+func (*CapabilitiesResponse) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *CapabilitiesResponse) GetCapabilities() []CapabilitiesResponse_Capability {
+	if x != nil {
+		return x.Capabilities
+	}
+	return nil
+}
+
 var File_ping_proto protoreflect.FileDescriptor
 
 const file_ping_proto_rawDesc = "" +
@@ -82,9 +178,19 @@ const file_ping_proto_rawDesc = "" +
 	"ping.proto\x12\x04ping\x1a\x1bgoogle/protobuf/empty.proto\"F\n" +
 	"\fPingResponse\x12\x1c\n" +
 	"\tcomponent\x18\x01 \x01(\tR\tcomponent\x12\x18\n" +
-	"\aversion\x18\x02 \x01(\tR\aversion2:\n" +
+	"\aversion\x18\x02 \x01(\tR\aversion\"\xb1\x01\n" +
+	"\x14CapabilitiesResponse\x12I\n" +
+	"\fcapabilities\x18\x01 \x03(\x0e2%.ping.CapabilitiesResponse.CapabilityR\fcapabilities\"N\n" +
+	"\n" +
+	"Capability\x12\x0f\n" +
+	"\vUNSPECIFIED\x10\x00\x12\x14\n" +
+	"\x10AUTH_INTERACTIVE\x10\x01\x12\x0e\n" +
+	"\n" +
+	"AUTH_AUTHZ\x10\x02\x12\t\n" +
+	"\x05DEBUG\x10\x032~\n" +
 	"\x04Ping\x122\n" +
-	"\x04Ping\x12\x16.google.protobuf.Empty\x1a\x12.ping.PingResponseB\vZ\x06pkg/pb\xba\x02\x00b\x06proto3"
+	"\x04Ping\x12\x16.google.protobuf.Empty\x1a\x12.ping.PingResponse\x12B\n" +
+	"\fCapabilities\x12\x16.google.protobuf.Empty\x1a\x1a.ping.CapabilitiesResponseB\vZ\x06pkg/pb\xba\x02\x00b\x06proto3"
 
 var (
 	file_ping_proto_rawDescOnce sync.Once
@@ -98,19 +204,25 @@ func file_ping_proto_rawDescGZIP() []byte {
 	return file_ping_proto_rawDescData
 }
 
-var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_ping_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_ping_proto_goTypes = []any{
-	(*PingResponse)(nil),  // 0: ping.PingResponse
-	(*emptypb.Empty)(nil), // 1: google.protobuf.Empty
+	(CapabilitiesResponse_Capability)(0), // 0: ping.CapabilitiesResponse.Capability
+	(*PingResponse)(nil),                 // 1: ping.PingResponse
+	(*CapabilitiesResponse)(nil),         // 2: ping.CapabilitiesResponse
+	(*emptypb.Empty)(nil),                // 3: google.protobuf.Empty
 }
 var file_ping_proto_depIdxs = []int32{
-	1, // 0: ping.Ping.Ping:input_type -> google.protobuf.Empty
-	0, // 1: ping.Ping.Ping:output_type -> ping.PingResponse
-	1, // [1:2] is the sub-list for method output_type
-	0, // [0:1] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	0, // 0: ping.CapabilitiesResponse.capabilities:type_name -> ping.CapabilitiesResponse.Capability
+	3, // 1: ping.Ping.Ping:input_type -> google.protobuf.Empty
+	3, // 2: ping.Ping.Capabilities:input_type -> google.protobuf.Empty
+	1, // 3: ping.Ping.Ping:output_type -> ping.PingResponse
+	2, // 4: ping.Ping.Capabilities:output_type -> ping.CapabilitiesResponse
+	3, // [3:5] is the sub-list for method output_type
+	1, // [1:3] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_ping_proto_init() }
@@ -123,13 +235,14 @@ func file_ping_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ping_proto_rawDesc), len(file_ping_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   1,
+			NumEnums:      1,
+			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_ping_proto_goTypes,
 		DependencyIndexes: file_ping_proto_depIdxs,
+		EnumInfos:         file_ping_proto_enumTypes,
 		MessageInfos:      file_ping_proto_msgTypes,
 	}.Build()
 	File_ping_proto = out.File

--- a/pkg/pb/ping_grpc.pb.go
+++ b/pkg/pb/ping_grpc.pb.go
@@ -20,7 +20,8 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	Ping_Ping_FullMethodName = "/ping.Ping/Ping"
+	Ping_Ping_FullMethodName         = "/ping.Ping/Ping"
+	Ping_Capabilities_FullMethodName = "/ping.Ping/Capabilities"
 )
 
 // PingClient is the client API for Ping service.
@@ -28,6 +29,7 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type PingClient interface {
 	Ping(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*PingResponse, error)
+	Capabilities(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*CapabilitiesResponse, error)
 }
 
 type pingClient struct {
@@ -48,11 +50,22 @@ func (c *pingClient) Ping(ctx context.Context, in *emptypb.Empty, opts ...grpc.C
 	return out, nil
 }
 
+func (c *pingClient) Capabilities(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*CapabilitiesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CapabilitiesResponse)
+	err := c.cc.Invoke(ctx, Ping_Capabilities_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // PingServer is the server API for Ping service.
 // All implementations must embed UnimplementedPingServer
 // for forward compatibility.
 type PingServer interface {
 	Ping(context.Context, *emptypb.Empty) (*PingResponse, error)
+	Capabilities(context.Context, *emptypb.Empty) (*CapabilitiesResponse, error)
 	mustEmbedUnimplementedPingServer()
 }
 
@@ -65,6 +78,9 @@ type UnimplementedPingServer struct{}
 
 func (UnimplementedPingServer) Ping(context.Context, *emptypb.Empty) (*PingResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Ping not implemented")
+}
+func (UnimplementedPingServer) Capabilities(context.Context, *emptypb.Empty) (*CapabilitiesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Capabilities not implemented")
 }
 func (UnimplementedPingServer) mustEmbedUnimplementedPingServer() {}
 func (UnimplementedPingServer) testEmbeddedByValue()              {}
@@ -105,6 +121,24 @@ func _Ping_Ping_Handler(srv interface{}, ctx context.Context, dec func(interface
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Ping_Capabilities_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(emptypb.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PingServer).Capabilities(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Ping_Capabilities_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PingServer).Capabilities(ctx, req.(*emptypb.Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Ping_ServiceDesc is the grpc.ServiceDesc for Ping service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -115,6 +149,10 @@ var Ping_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Ping",
 			Handler:    _Ping_Ping_Handler,
+		},
+		{
+			MethodName: "Capabilities",
+			Handler:    _Ping_Capabilities_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pkg/pb/sys_ctrl.pb.go
+++ b/pkg/pb/sys_ctrl.pb.go
@@ -22,58 +22,6 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-type CapabilitiesResponse_Capability int32
-
-const (
-	CapabilitiesResponse_UNSPECIFIED      CapabilitiesResponse_Capability = 0
-	CapabilitiesResponse_AUTH_INTERACTIVE CapabilitiesResponse_Capability = 1
-	CapabilitiesResponse_AUTH_AUTHZ       CapabilitiesResponse_Capability = 2
-	CapabilitiesResponse_DEBUG            CapabilitiesResponse_Capability = 3
-)
-
-// Enum value maps for CapabilitiesResponse_Capability.
-var (
-	CapabilitiesResponse_Capability_name = map[int32]string{
-		0: "UNSPECIFIED",
-		1: "AUTH_INTERACTIVE",
-		2: "AUTH_AUTHZ",
-		3: "DEBUG",
-	}
-	CapabilitiesResponse_Capability_value = map[string]int32{
-		"UNSPECIFIED":      0,
-		"AUTH_INTERACTIVE": 1,
-		"AUTH_AUTHZ":       2,
-		"DEBUG":            3,
-	}
-)
-
-func (x CapabilitiesResponse_Capability) Enum() *CapabilitiesResponse_Capability {
-	p := new(CapabilitiesResponse_Capability)
-	*p = x
-	return p
-}
-
-func (x CapabilitiesResponse_Capability) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (CapabilitiesResponse_Capability) Descriptor() protoreflect.EnumDescriptor {
-	return file_sys_ctrl_proto_enumTypes[0].Descriptor()
-}
-
-func (CapabilitiesResponse_Capability) Type() protoreflect.EnumType {
-	return &file_sys_ctrl_proto_enumTypes[0]
-}
-
-func (x CapabilitiesResponse_Capability) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use CapabilitiesResponse_Capability.Descriptor instead.
-func (CapabilitiesResponse_Capability) EnumDescriptor() ([]byte, []int) {
-	return file_sys_ctrl_proto_rawDescGZIP(), []int{5, 0}
-}
-
 type Domain struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -326,50 +274,6 @@ func (x *TroubleshootInspectResponse) GetChildren() []*TroubleshootInspectRespon
 	return nil
 }
 
-type CapabilitiesResponse struct {
-	state         protoimpl.MessageState            `protogen:"open.v1"`
-	Capabilities  []CapabilitiesResponse_Capability `protobuf:"varint,1,rep,packed,name=capabilities,proto3,enum=sys_ctrl.CapabilitiesResponse_Capability" json:"capabilities,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *CapabilitiesResponse) Reset() {
-	*x = CapabilitiesResponse{}
-	mi := &file_sys_ctrl_proto_msgTypes[5]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *CapabilitiesResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*CapabilitiesResponse) ProtoMessage() {}
-
-func (x *CapabilitiesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_sys_ctrl_proto_msgTypes[5]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use CapabilitiesResponse.ProtoReflect.Descriptor instead.
-func (*CapabilitiesResponse) Descriptor() ([]byte, []int) {
-	return file_sys_ctrl_proto_rawDescGZIP(), []int{5}
-}
-
-func (x *CapabilitiesResponse) GetCapabilities() []CapabilitiesResponse_Capability {
-	if x != nil {
-		return x.Capabilities
-	}
-	return nil
-}
-
 var File_sys_ctrl_proto protoreflect.FileDescriptor
 
 const file_sys_ctrl_proto_rawDesc = "" +
@@ -391,24 +295,14 @@ const file_sys_ctrl_proto_rawDesc = "" +
 	"\bchildren\x18\x03 \x03(\v2%.sys_ctrl.TroubleshootInspectResponseR\bchildren\x1a5\n" +
 	"\aKvEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb5\x01\n" +
-	"\x14CapabilitiesResponse\x12M\n" +
-	"\fcapabilities\x18\x01 \x03(\x0e2).sys_ctrl.CapabilitiesResponse.CapabilityR\fcapabilities\"N\n" +
-	"\n" +
-	"Capability\x12\x0f\n" +
-	"\vUNSPECIFIED\x10\x00\x12\x14\n" +
-	"\x10AUTH_INTERACTIVE\x10\x01\x12\x0e\n" +
-	"\n" +
-	"AUTH_AUTHZ\x10\x02\x12\t\n" +
-	"\x05DEBUG\x10\x032\xf9\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x012\xb1\x02\n" +
 	"\n" +
 	"SystemCtrl\x12B\n" +
 	"\n" +
 	"DomainList\x12\x16.google.protobuf.Empty\x1a\x1c.sys_ctrl.DomainListResponse\x12M\n" +
 	"\fDomainEnroll\x12\x1d.sys_ctrl.DomainEnrollRequest\x1a\x1e.sys_ctrl.DomainEnrollResponse\x12:\n" +
 	"\x0eDomainUnenroll\x12\x10.sys_ctrl.Domain\x1a\x16.google.protobuf.Empty\x12T\n" +
-	"\x13TroubleshootInspect\x12\x16.google.protobuf.Empty\x1a%.sys_ctrl.TroubleshootInspectResponse\x12F\n" +
-	"\fCapabilities\x12\x16.google.protobuf.Empty\x1a\x1e.sys_ctrl.CapabilitiesResponseB\vZ\x06pkg/pb\xba\x02\x00b\x06proto3"
+	"\x13TroubleshootInspect\x12\x16.google.protobuf.Empty\x1a%.sys_ctrl.TroubleshootInspectResponseB\vZ\x06pkg/pb\xba\x02\x00b\x06proto3"
 
 var (
 	file_sys_ctrl_proto_rawDescOnce sync.Once
@@ -422,39 +316,33 @@ func file_sys_ctrl_proto_rawDescGZIP() []byte {
 	return file_sys_ctrl_proto_rawDescData
 }
 
-var file_sys_ctrl_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_sys_ctrl_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_sys_ctrl_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_sys_ctrl_proto_goTypes = []any{
-	(CapabilitiesResponse_Capability)(0), // 0: sys_ctrl.CapabilitiesResponse.Capability
-	(*Domain)(nil),                       // 1: sys_ctrl.Domain
-	(*DomainListResponse)(nil),           // 2: sys_ctrl.DomainListResponse
-	(*DomainEnrollRequest)(nil),          // 3: sys_ctrl.DomainEnrollRequest
-	(*DomainEnrollResponse)(nil),         // 4: sys_ctrl.DomainEnrollResponse
-	(*TroubleshootInspectResponse)(nil),  // 5: sys_ctrl.TroubleshootInspectResponse
-	(*CapabilitiesResponse)(nil),         // 6: sys_ctrl.CapabilitiesResponse
-	nil,                                  // 7: sys_ctrl.TroubleshootInspectResponse.KvEntry
-	(*emptypb.Empty)(nil),                // 8: google.protobuf.Empty
+	(*Domain)(nil),                      // 0: sys_ctrl.Domain
+	(*DomainListResponse)(nil),          // 1: sys_ctrl.DomainListResponse
+	(*DomainEnrollRequest)(nil),         // 2: sys_ctrl.DomainEnrollRequest
+	(*DomainEnrollResponse)(nil),        // 3: sys_ctrl.DomainEnrollResponse
+	(*TroubleshootInspectResponse)(nil), // 4: sys_ctrl.TroubleshootInspectResponse
+	nil,                                 // 5: sys_ctrl.TroubleshootInspectResponse.KvEntry
+	(*emptypb.Empty)(nil),               // 6: google.protobuf.Empty
 }
 var file_sys_ctrl_proto_depIdxs = []int32{
-	1, // 0: sys_ctrl.DomainListResponse.domains:type_name -> sys_ctrl.Domain
-	7, // 1: sys_ctrl.TroubleshootInspectResponse.kv:type_name -> sys_ctrl.TroubleshootInspectResponse.KvEntry
-	5, // 2: sys_ctrl.TroubleshootInspectResponse.children:type_name -> sys_ctrl.TroubleshootInspectResponse
-	0, // 3: sys_ctrl.CapabilitiesResponse.capabilities:type_name -> sys_ctrl.CapabilitiesResponse.Capability
-	8, // 4: sys_ctrl.SystemCtrl.DomainList:input_type -> google.protobuf.Empty
-	3, // 5: sys_ctrl.SystemCtrl.DomainEnroll:input_type -> sys_ctrl.DomainEnrollRequest
-	1, // 6: sys_ctrl.SystemCtrl.DomainUnenroll:input_type -> sys_ctrl.Domain
-	8, // 7: sys_ctrl.SystemCtrl.TroubleshootInspect:input_type -> google.protobuf.Empty
-	8, // 8: sys_ctrl.SystemCtrl.Capabilities:input_type -> google.protobuf.Empty
-	2, // 9: sys_ctrl.SystemCtrl.DomainList:output_type -> sys_ctrl.DomainListResponse
-	4, // 10: sys_ctrl.SystemCtrl.DomainEnroll:output_type -> sys_ctrl.DomainEnrollResponse
-	8, // 11: sys_ctrl.SystemCtrl.DomainUnenroll:output_type -> google.protobuf.Empty
-	5, // 12: sys_ctrl.SystemCtrl.TroubleshootInspect:output_type -> sys_ctrl.TroubleshootInspectResponse
-	6, // 13: sys_ctrl.SystemCtrl.Capabilities:output_type -> sys_ctrl.CapabilitiesResponse
-	9, // [9:14] is the sub-list for method output_type
-	4, // [4:9] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	0, // 0: sys_ctrl.DomainListResponse.domains:type_name -> sys_ctrl.Domain
+	5, // 1: sys_ctrl.TroubleshootInspectResponse.kv:type_name -> sys_ctrl.TroubleshootInspectResponse.KvEntry
+	4, // 2: sys_ctrl.TroubleshootInspectResponse.children:type_name -> sys_ctrl.TroubleshootInspectResponse
+	6, // 3: sys_ctrl.SystemCtrl.DomainList:input_type -> google.protobuf.Empty
+	2, // 4: sys_ctrl.SystemCtrl.DomainEnroll:input_type -> sys_ctrl.DomainEnrollRequest
+	0, // 5: sys_ctrl.SystemCtrl.DomainUnenroll:input_type -> sys_ctrl.Domain
+	6, // 6: sys_ctrl.SystemCtrl.TroubleshootInspect:input_type -> google.protobuf.Empty
+	1, // 7: sys_ctrl.SystemCtrl.DomainList:output_type -> sys_ctrl.DomainListResponse
+	3, // 8: sys_ctrl.SystemCtrl.DomainEnroll:output_type -> sys_ctrl.DomainEnrollResponse
+	6, // 9: sys_ctrl.SystemCtrl.DomainUnenroll:output_type -> google.protobuf.Empty
+	4, // 10: sys_ctrl.SystemCtrl.TroubleshootInspect:output_type -> sys_ctrl.TroubleshootInspectResponse
+	7, // [7:11] is the sub-list for method output_type
+	3, // [3:7] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_sys_ctrl_proto_init() }
@@ -467,14 +355,13 @@ func file_sys_ctrl_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_sys_ctrl_proto_rawDesc), len(file_sys_ctrl_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   7,
+			NumEnums:      0,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_sys_ctrl_proto_goTypes,
 		DependencyIndexes: file_sys_ctrl_proto_depIdxs,
-		EnumInfos:         file_sys_ctrl_proto_enumTypes,
 		MessageInfos:      file_sys_ctrl_proto_msgTypes,
 	}.Build()
 	File_sys_ctrl_proto = out.File

--- a/pkg/pb/sys_ctrl_grpc.pb.go
+++ b/pkg/pb/sys_ctrl_grpc.pb.go
@@ -24,7 +24,6 @@ const (
 	SystemCtrl_DomainEnroll_FullMethodName        = "/sys_ctrl.SystemCtrl/DomainEnroll"
 	SystemCtrl_DomainUnenroll_FullMethodName      = "/sys_ctrl.SystemCtrl/DomainUnenroll"
 	SystemCtrl_TroubleshootInspect_FullMethodName = "/sys_ctrl.SystemCtrl/TroubleshootInspect"
-	SystemCtrl_Capabilities_FullMethodName        = "/sys_ctrl.SystemCtrl/Capabilities"
 )
 
 // SystemCtrlClient is the client API for SystemCtrl service.
@@ -35,7 +34,6 @@ type SystemCtrlClient interface {
 	DomainEnroll(ctx context.Context, in *DomainEnrollRequest, opts ...grpc.CallOption) (*DomainEnrollResponse, error)
 	DomainUnenroll(ctx context.Context, in *Domain, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	TroubleshootInspect(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*TroubleshootInspectResponse, error)
-	Capabilities(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*CapabilitiesResponse, error)
 }
 
 type systemCtrlClient struct {
@@ -86,16 +84,6 @@ func (c *systemCtrlClient) TroubleshootInspect(ctx context.Context, in *emptypb.
 	return out, nil
 }
 
-func (c *systemCtrlClient) Capabilities(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*CapabilitiesResponse, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(CapabilitiesResponse)
-	err := c.cc.Invoke(ctx, SystemCtrl_Capabilities_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
 // SystemCtrlServer is the server API for SystemCtrl service.
 // All implementations must embed UnimplementedSystemCtrlServer
 // for forward compatibility.
@@ -104,7 +92,6 @@ type SystemCtrlServer interface {
 	DomainEnroll(context.Context, *DomainEnrollRequest) (*DomainEnrollResponse, error)
 	DomainUnenroll(context.Context, *Domain) (*emptypb.Empty, error)
 	TroubleshootInspect(context.Context, *emptypb.Empty) (*TroubleshootInspectResponse, error)
-	Capabilities(context.Context, *emptypb.Empty) (*CapabilitiesResponse, error)
 	mustEmbedUnimplementedSystemCtrlServer()
 }
 
@@ -126,9 +113,6 @@ func (UnimplementedSystemCtrlServer) DomainUnenroll(context.Context, *Domain) (*
 }
 func (UnimplementedSystemCtrlServer) TroubleshootInspect(context.Context, *emptypb.Empty) (*TroubleshootInspectResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method TroubleshootInspect not implemented")
-}
-func (UnimplementedSystemCtrlServer) Capabilities(context.Context, *emptypb.Empty) (*CapabilitiesResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method Capabilities not implemented")
 }
 func (UnimplementedSystemCtrlServer) mustEmbedUnimplementedSystemCtrlServer() {}
 func (UnimplementedSystemCtrlServer) testEmbeddedByValue()                    {}
@@ -223,24 +207,6 @@ func _SystemCtrl_TroubleshootInspect_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
-func _SystemCtrl_Capabilities_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(emptypb.Empty)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(SystemCtrlServer).Capabilities(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: SystemCtrl_Capabilities_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(SystemCtrlServer).Capabilities(ctx, req.(*emptypb.Empty))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
 // SystemCtrl_ServiceDesc is the grpc.ServiceDesc for SystemCtrl service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -263,10 +229,6 @@ var SystemCtrl_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "TroubleshootInspect",
 			Handler:    _SystemCtrl_TroubleshootInspect_Handler,
-		},
-		{
-			MethodName: "Capabilities",
-			Handler:    _SystemCtrl_Capabilities_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/protobuf/ping.proto
+++ b/protobuf/ping.proto
@@ -8,9 +8,20 @@ import "google/protobuf/empty.proto";
 
 service Ping {
   rpc Ping(google.protobuf.Empty) returns (PingResponse);
+  rpc Capabilities(google.protobuf.Empty) returns (CapabilitiesResponse);
 }
 
 message PingResponse {
   string component = 1;
   string version = 2;
+}
+
+message CapabilitiesResponse {
+  enum Capability {
+    UNSPECIFIED = 0;
+    AUTH_INTERACTIVE = 1;
+    AUTH_AUTHZ = 2;
+    DEBUG = 3;
+  }
+  repeated Capability capabilities = 1;
 }

--- a/protobuf/sys_ctrl.proto
+++ b/protobuf/sys_ctrl.proto
@@ -11,7 +11,6 @@ service SystemCtrl {
   rpc DomainEnroll(DomainEnrollRequest) returns (DomainEnrollResponse);
   rpc DomainUnenroll(Domain) returns (google.protobuf.Empty);
   rpc TroubleshootInspect(google.protobuf.Empty) returns (TroubleshootInspectResponse);
-  rpc Capabilities(google.protobuf.Empty) returns (CapabilitiesResponse);
 }
 
 message Domain {
@@ -36,14 +35,4 @@ message TroubleshootInspectResponse {
   string bucket = 1;
   map<string, string> kv = 2;
   repeated TroubleshootInspectResponse children = 3;
-}
-
-message CapabilitiesResponse {
-  enum Capability {
-    UNSPECIFIED = 0;
-    AUTH_INTERACTIVE = 1;
-    AUTH_AUTHZ = 2;
-    DEBUG = 3;
-  }
-  repeated Capability capabilities = 1;
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -6,12 +6,11 @@ use url::Url;
 use winreg::enums::HKEY_LOCAL_MACHINE;
 
 use crate::config::Config;
+use crate::generated::ping::capabilities_response::Capability;
 use crate::generated::ping::ping_client::PingClient;
 use crate::generated::sys_auth::TokenAuthRequest;
 use crate::generated::sys_auth::system_auth_interactive_client::SystemAuthInteractiveClient;
 use crate::generated::sys_auth::system_auth_token_client::SystemAuthTokenClient;
-use crate::generated::sys_ctrl::capabilities_response::Capability;
-use crate::generated::sys_ctrl::system_ctrl_client::SystemCtrlClient;
 use crate::grpc::{grpc_request, grpc_request_path};
 
 const TOKEN_QUERY_PARAM: &str = "ak-auth-ia-token";
@@ -130,7 +129,7 @@ fn ak_sys_caps() -> Result<ffi::Capabilities, Box<dyn Error>> {
         Err(_) => {
             let config = Config::get();
             let response = grpc_request(async |ch| {
-                return Ok(SystemCtrlClient::new(ch).capabilities(()).await?);
+                return Ok(PingClient::new(ch).capabilities(()).await?);
             })?
             .into_inner();
             let authia = Capability::AuthInteractive as i32;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -129,7 +129,7 @@ fn ak_sys_caps() -> Result<ffi::Capabilities, Box<dyn Error>> {
         Ok(t) => t,
         Err(_) => {
             let config = Config::get();
-            let response = grpc_request_path(config.socket_ctrl.to_owned(), async |ch| {
+            let response = grpc_request(async |ch| {
                 return Ok(SystemCtrlClient::new(ch).capabilities(()).await?);
             })?
             .into_inner();

--- a/src/generated/ping/ping.rs
+++ b/src/generated/ping/ping.rs
@@ -7,5 +7,45 @@ pub struct PingResponse {
     #[prost(string, tag="2")]
     pub version: ::prost::alloc::string::String,
 }
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct CapabilitiesResponse {
+    #[prost(enumeration="capabilities_response::Capability", repeated, tag="1")]
+    pub capabilities: ::prost::alloc::vec::Vec<i32>,
+}
+/// Nested message and enum types in `CapabilitiesResponse`.
+pub mod capabilities_response {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Capability {
+        Unspecified = 0,
+        AuthInteractive = 1,
+        AuthAuthz = 2,
+        Debug = 3,
+    }
+    impl Capability {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Self::Unspecified => "UNSPECIFIED",
+                Self::AuthInteractive => "AUTH_INTERACTIVE",
+                Self::AuthAuthz => "AUTH_AUTHZ",
+                Self::Debug => "DEBUG",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "UNSPECIFIED" => Some(Self::Unspecified),
+                "AUTH_INTERACTIVE" => Some(Self::AuthInteractive),
+                "AUTH_AUTHZ" => Some(Self::AuthAuthz),
+                "DEBUG" => Some(Self::Debug),
+                _ => None,
+            }
+        }
+    }
+}
 include!("ping.tonic.rs");
 // @@protoc_insertion_point(module)

--- a/src/generated/ping/ping.tonic.rs
+++ b/src/generated/ping/ping.tonic.rs
@@ -108,5 +108,26 @@ pub mod ping_client {
             req.extensions_mut().insert(GrpcMethod::new("ping.Ping", "Ping"));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn capabilities(
+            &mut self,
+            request: impl tonic::IntoRequest<()>,
+        ) -> std::result::Result<
+            tonic::Response<super::CapabilitiesResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/ping.Ping/Capabilities");
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("ping.Ping", "Capabilities"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }

--- a/src/generated/sys_ctrl/sys_ctrl.rs
+++ b/src/generated/sys_ctrl/sys_ctrl.rs
@@ -33,45 +33,5 @@ pub struct TroubleshootInspectResponse {
     #[prost(message, repeated, tag="3")]
     pub children: ::prost::alloc::vec::Vec<TroubleshootInspectResponse>,
 }
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct CapabilitiesResponse {
-    #[prost(enumeration="capabilities_response::Capability", repeated, tag="1")]
-    pub capabilities: ::prost::alloc::vec::Vec<i32>,
-}
-/// Nested message and enum types in `CapabilitiesResponse`.
-pub mod capabilities_response {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-    #[repr(i32)]
-    pub enum Capability {
-        Unspecified = 0,
-        AuthInteractive = 1,
-        AuthAuthz = 2,
-        Debug = 3,
-    }
-    impl Capability {
-        /// String value of the enum field names used in the ProtoBuf definition.
-        ///
-        /// The values are not transformed in any way and thus are considered stable
-        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn as_str_name(&self) -> &'static str {
-            match self {
-                Self::Unspecified => "UNSPECIFIED",
-                Self::AuthInteractive => "AUTH_INTERACTIVE",
-                Self::AuthAuthz => "AUTH_AUTHZ",
-                Self::Debug => "DEBUG",
-            }
-        }
-        /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-            match value {
-                "UNSPECIFIED" => Some(Self::Unspecified),
-                "AUTH_INTERACTIVE" => Some(Self::AuthInteractive),
-                "AUTH_AUTHZ" => Some(Self::AuthAuthz),
-                "DEBUG" => Some(Self::Debug),
-                _ => None,
-            }
-        }
-    }
-}
 include!("sys_ctrl.tonic.rs");
 // @@protoc_insertion_point(module)

--- a/src/generated/sys_ctrl/sys_ctrl.tonic.rs
+++ b/src/generated/sys_ctrl/sys_ctrl.tonic.rs
@@ -183,29 +183,5 @@ pub mod system_ctrl_client {
                 .insert(GrpcMethod::new("sys_ctrl.SystemCtrl", "TroubleshootInspect"));
             self.inner.unary(req, path, codec).await
         }
-        pub async fn capabilities(
-            &mut self,
-            request: impl tonic::IntoRequest<()>,
-        ) -> std::result::Result<
-            tonic::Response<super::CapabilitiesResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic_prost::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/sys_ctrl.SystemCtrl/Capabilities",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("sys_ctrl.SystemCtrl", "Capabilities"));
-            self.inner.unary(req, path, codec).await
-        }
     }
 }


### PR DESCRIPTION
some of the caps were previously in the auth server, which was then moved to the ctrl server since it made more sense, and is fine on linux and windows, however on macOS a user-scoped process needs to check caps, so this moves it to the ping server and the standard server.

This might also fix issues on ubuntu 26.04 due to permissions