### PR TITLE
root: only show version build hash for non-tagged builds

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -6,6 +6,7 @@ GID = $(shell id -g)
 VERSION = 0.41.5
 VERSION_HASH = $(shell git rev-parse HEAD)
 VERSION_HASH_SHORT = $(shell git rev-parse HEAD | head -c 8)
+VERSION_TAG = $(shell git tag --points-at HEAD)
 VERSION_TS = $(shell date +%s)
 PLATFORM := $(shell bash -c "uname -o | tr '[:upper:]' '[:lower:]'")
 ifeq ($(OS),Windows_NT)
@@ -19,7 +20,10 @@ endif
 TOP = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 PROTO_DIR := "${TOP}/protobuf"
 
-_LD_FLAGS = ${LD_FLAGS} -X goauthentik.io/platform/pkg/meta.Version=${VERSION} -X goauthentik.io/platform/pkg/meta.BuildHash=${VERSION_HASH}
+_LD_FLAGS = ${LD_FLAGS} \
+	-X goauthentik.io/platform/pkg/meta.Version=${VERSION} \
+	-X goauthentik.io/platform/pkg/meta.BuildHash=${VERSION_HASH} \
+	-X goauthentik.io/platform/pkg/meta.Tag=${VERSION_TAG}
 GO_BUILD_FLAGS = -ldflags "${_LD_FLAGS}" -v ${AK_GO_BUILD_FLAGS}
 RUST_BUILD_FLAGS =
 

--- a/pkg/meta/version.go
+++ b/pkg/meta/version.go
@@ -9,12 +9,13 @@ import (
 var (
 	Version   = ""
 	BuildHash = ""
+	Tag       = ""
 )
 
 func FullVersion() string {
 	version := strings.Builder{}
 	version.WriteString(Version)
-	if BuildHash != "" {
+	if BuildHash != "" && Tag == "" {
 		version.WriteRune('-')
 		if len(BuildHash) >= 8 {
 			version.WriteString(BuildHash[:8])

--- a/pkg/meta/version_test.go
+++ b/pkg/meta/version_test.go
@@ -1,0 +1,29 @@
+package meta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_VersionBranch(t *testing.T) {
+	Version = "1.2.3"
+	BuildHash = "foobarbaz"
+	Tag = ""
+	assert.Equal(t, "1.2.3-foobarba", FullVersion())
+	assert.Equal(t, "https://github.com/goauthentik/platform/commit/foobarbaz", BuildURL())
+}
+
+func Test_Tag(t *testing.T) {
+	Version = "1.2.3"
+	BuildHash = "foobarbaz"
+	Tag = "v1.2.3"
+	assert.Equal(t, "1.2.3", FullVersion())
+}
+
+func Test_VersionBranch_Short(t *testing.T) {
+	Version = "1.2.3"
+	BuildHash = "foobarb"
+	Tag = ""
+	assert.Equal(t, "1.2.3-foobarb", FullVersion())
+}


### PR DESCRIPTION
Before:

```
 ak version
authentik Agent CLI: 0.41.5-cfa4587c
Agent: 0.41.5-cfa4587c
System: 0.41.5-cfa4587c
```

after:

```
 ./bin/cli/ak version
authentik Agent CLI: 0.41.5
Agent: 0.41.5
System: 0.41.5
```