### PR TITLE
facts: omit blank OS strings

### DIFF
--- a/pkg/platform/facts/os/os.go
+++ b/pkg/platform/facts/os/os.go
@@ -1,6 +1,8 @@
 package os
 
 import (
+	"strings"
+
 	"goauthentik.io/api/v3"
 	"goauthentik.io/platform/pkg/platform/facts/common"
 )
@@ -9,6 +11,14 @@ import (
 func Gather(ctx *common.GatherContext) (api.DeviceFactsRequestOs, error) {
 	ctx.Log().Debug("Gathering...")
 	return gather(ctx)
+}
+
+func ptrStringIfNotBlank(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return api.PtrString(value)
 }
 
 func extractVersion(versionData map[string]string) (string, string) {

--- a/pkg/platform/facts/os/os_darwin.go
+++ b/pkg/platform/facts/os/os_darwin.go
@@ -18,8 +18,8 @@ func gather(ctx *common.GatherContext) (api.DeviceFactsRequestOs, error) {
 	return api.DeviceFactsRequestOs{
 		Arch:    runtime.GOARCH,
 		Family:  api.DEVICEFACTSOSFAMILY_MAC_OS,
-		Name:    new(name),
-		Version: new(version),
+		Name:    ptrStringIfNotBlank(name),
+		Version: ptrStringIfNotBlank(version),
 	}, nil
 }
 

--- a/pkg/platform/facts/os/os_linux.go
+++ b/pkg/platform/facts/os/os_linux.go
@@ -18,8 +18,8 @@ func gather(ctx *common.GatherContext) (api.DeviceFactsRequestOs, error) {
 	return api.DeviceFactsRequestOs{
 		Arch:    runtime.GOARCH,
 		Family:  api.DEVICEFACTSOSFAMILY_LINUX,
-		Name:    api.PtrString(name),
-		Version: api.PtrString(version),
+		Name:    ptrStringIfNotBlank(name),
+		Version: ptrStringIfNotBlank(version),
 	}, nil
 }
 

--- a/pkg/platform/facts/os/os_test.go
+++ b/pkg/platform/facts/os/os_test.go
@@ -1,6 +1,7 @@
 package os
 
 import (
+	"encoding/json"
 	"runtime"
 	"slices"
 	"testing"
@@ -113,6 +114,26 @@ func TestExtract(t *testing.T) {
 			assert.Equal(t, tc.version, version)
 		})
 	}
+}
+
+func TestPtrStringIfNotBlank(t *testing.T) {
+	assert.Nil(t, ptrStringIfNotBlank(""))
+	assert.Nil(t, ptrStringIfNotBlank(" \t\n"))
+
+	value := ptrStringIfNotBlank("  24.04  ")
+	assert.NotNil(t, value)
+	assert.Equal(t, "24.04", *value)
+}
+
+func TestMarshalOmitsBlankOptionalStrings(t *testing.T) {
+	data, err := json.Marshal(api.DeviceFactsRequestOs{
+		Arch:    "amd64",
+		Family:  api.DEVICEFACTSOSFAMILY_LINUX,
+		Name:    ptrStringIfNotBlank("Linux"),
+		Version: ptrStringIfNotBlank(""),
+	})
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"arch":"amd64","family":"linux","name":"Linux"}`, string(data))
 }
 
 func TestGatherLinux(t *testing.T) {

--- a/pkg/platform/facts/os/os_windows.go
+++ b/pkg/platform/facts/os/os_windows.go
@@ -4,7 +4,6 @@ package os
 
 import (
 	"runtime"
-	"strings"
 
 	"goauthentik.io/api/v3"
 	"goauthentik.io/platform/pkg/platform/facts/common"
@@ -35,7 +34,7 @@ func gather(ctx *common.GatherContext) (api.DeviceFactsRequestOs, error) {
 	return api.DeviceFactsRequestOs{
 		Arch:    runtime.GOARCH,
 		Family:  api.DEVICEFACTSOSFAMILY_WINDOWS,
-		Name:    api.PtrString(strings.TrimSpace(productName)),
-		Version: api.PtrString(strings.TrimSpace(version)),
+		Name:    ptrStringIfNotBlank(productName),
+		Version: ptrStringIfNotBlank(version),
 	}, nil
 }


### PR DESCRIPTION
## Summary
Omit optional OS fact strings when platform cannot report a non-empty value.

This follows up on goauthentik/platform@3179a52 / #949: OS version extraction was improved there, but a remaining empty result was still wrapped with `api.PtrString("")`. Because the generated API client only omits nil pointers, that serialized as `"version": ""` during agent check-in.

## Related
This fixes the blank OS version producer-side issue seen by authentik endpoint e2e tests. The separate authentik proxy e2e CI fix is goauthentik/authentik#22770.

## Validation
- `go test ./pkg/platform/facts/os`
- `go test ./pkg/platform/facts/...`
- `git diff --check`