### PR TITLE
ci: fix glibc requirement

### DIFF
--- a/.github/workflows/_build-rs.yml
+++ b/.github/workflows/_build-rs.yml
@@ -53,6 +53,9 @@ jobs:
         with:
           path: cache/
           key: target-cache-${{ matrix.target }}-${{ matrix.platform }}
+      - name: Build builder image
+        if: startsWith(matrix.platform, 'ubuntu')
+        run: make containers/builder/build
       - run: |
           make ${{ matrix.target }}/build
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -240,6 +240,7 @@ jobs:
           AK_PASSWORD: ${{ steps.setup.outputs.admin_password }}
           AK_TOKEN: ${{ steps.setup.outputs.admin_token }}
         run: |
+          make containers/builder/build
           make test-e2e
       - run: |
           sudo chmod -R 777 ./e2e/coverage

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,9 @@ vpkg/windows/%:
 vpkg/linux/%:
 	"$(MAKE)" -C "${TOP}/vpkg/linux" $*
 
+containers/builder/%:
+	"$(MAKE)" -C "${TOP}/containers/builder" $*
+
 containers/selenium/%:
 	"$(MAKE)" -C "${TOP}/containers/selenium" $*
 

--- a/ak-browser-support/Makefile
+++ b/ak-browser-support/Makefile
@@ -15,10 +15,7 @@ clean:
 build:
 	mkdir -p "${TOP}/bin/${TARGET}"
 	mkdir -p "${TOP}/cache/${TARGET}"
-	RUSTFLAGS="${RUST_BUILD_FLAGS}" cargo build \
-		--target-dir "${TOP}/cache/${TARGET}" \
-		--verbose \
-		--release
+	$(call cargo_build,$(TARGET))
 	cp "${TOP}/cache/${TARGET}/release/${BIN}" "${TOP}/bin/${TARGET}/${BIND}"
 
 .PHONY: test

--- a/ak-cli/Makefile
+++ b/ak-cli/Makefile
@@ -14,10 +14,7 @@ clean:
 build:
 	mkdir -p "${TOP}/bin/${TARGET}"
 	mkdir -p "${TOP}/cache/${TARGET}"
-	RUSTFLAGS="${RUST_BUILD_FLAGS}" cargo build \
-		--target-dir "${TOP}/cache/${TARGET}" \
-		--verbose \
-		--release
+	$(call cargo_build,$(TARGET))
 	cp "${TOP}/cache/${TARGET}/release/${BIN}" "${TOP}/bin/${TARGET}/${BIND}"
 
 test-deploy: build

--- a/ak-nss/Makefile
+++ b/ak-nss/Makefile
@@ -5,10 +5,7 @@ TARGET = nss
 build:
 	mkdir -p ${TOP}/bin/${TARGET}
 	mkdir -p ${TOP}/cache/${TARGET}
-	RUSTFLAGS="${RUST_BUILD_FLAGS}" cargo build \
-		--target-dir ${TOP}/cache/${TARGET} \
-		--verbose \
-		--release
+	$(call cargo_build,$(TARGET))
 	cp "${TOP}/cache/${TARGET}/release/libnss_authentik.so" "${TOP}/bin/${TARGET}/"
 
 test:

--- a/ak-pam/Makefile
+++ b/ak-pam/Makefile
@@ -2,13 +2,10 @@ include ../common.mk
 
 TARGET = pam
 
-build: ci-install-deps
+build:
 	mkdir -p ${TOP}/bin/${TARGET}
 	mkdir -p ${TOP}/cache/${TARGET}
-	RUSTFLAGS="${RUST_BUILD_FLAGS}" cargo build \
-		--target-dir ${TOP}/cache/${TARGET} \
-		--verbose \
-		--release
+	$(call cargo_build,$(TARGET))
 	cp "${TOP}/cache/${TARGET}/release/libpam_authentik.so" "${TOP}/bin/${TARGET}/"
 
 test:

--- a/common.mk
+++ b/common.mk
@@ -46,7 +46,7 @@ endif
 ifeq ($(PLATFORM),gnu/linux)
 define cargo_build
 	docker run --rm \
-		-it \
+		-i \
 		--volume "$(CONTAINER_TOP):/workspace" \
 		--workdir "/workspace/$(CARGO_CRATE_DIR)" \
 		--env RUSTFLAGS="$(RUST_BUILD_FLAGS)" \

--- a/common.mk
+++ b/common.mk
@@ -34,6 +34,36 @@ _LD_FLAGS = ${LD_FLAGS} \
 	-X goauthentik.io/platform/pkg/meta.Tag=${VERSION_TAG}
 GO_BUILD_FLAGS = -ldflags "${_LD_FLAGS}" -v ${AK_GO_BUILD_FLAGS}
 RUST_BUILD_FLAGS =
+DOCKER_BUILDER_IMAGE ?= authentik/ak-builder
+CARGO_CRATE_DIR := $(subst $(TOP),,$(CURDIR))
+
+ifneq ($(LOCAL_WORKSPACE),)
+CONTAINER_TOP := ${LOCAL_WORKSPACE}
+else
+CONTAINER_TOP := ${TOP}
+endif
+
+ifeq ($(PLATFORM),gnu/linux)
+define cargo_build
+	docker run --rm \
+		-it \
+		--volume "$(CONTAINER_TOP):/workspace" \
+		--workdir "/workspace/$(CARGO_CRATE_DIR)" \
+		--env RUSTFLAGS="$(RUST_BUILD_FLAGS)" \
+		$(DOCKER_BUILDER_IMAGE) \
+		cargo build \
+			--target-dir /workspace/cache/$(1) \
+			--verbose \
+			--release
+endef
+else
+define cargo_build
+	RUSTFLAGS="$(RUST_BUILD_FLAGS)" cargo build \
+		--target-dir $(TOP)cache/$(1) \
+		--verbose \
+		--release
+endef
+endif
 
 TME := docker exec authentik-platform_devcontainer-test-machine-1
 

--- a/containers/builder/Dockerfile
+++ b/containers/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM debian:bullseye-slim
 
 ENV DEBIAN_FRONTEND=noninteractive \
     RUSTUP_HOME=/usr/local/rustup \

--- a/containers/builder/Dockerfile
+++ b/containers/builder/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        pkg-config \
+        libssl-dev \
+        libpam0g-dev \
+        libudev-dev \
+        curl \
+        ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --no-modify-path --default-toolchain stable && \
+    chmod -R a+rX /usr/local/rustup /usr/local/cargo

--- a/containers/builder/Makefile
+++ b/containers/builder/Makefile
@@ -1,0 +1,5 @@
+include ../../common.mk
+
+.PHONY: build
+build:
+	docker build -t ${DOCKER_BUILDER_IMAGE} .


### PR DESCRIPTION
closes https://github.com/goauthentik/platform/issues/1013

Currently the rust binaries built require GLIBC_2.39 from `2024-01-31`

After this the greatest requirement is GLIBC_2.30 which is from `2019-08-01`