### PR TITLE
ak-cli: allow switching between profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-os",
  "tauri-plugin-single-instance",
  "tracing",
 ]
@@ -7970,6 +7971,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "sysinfo"
 version = "0.39.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8220,6 +8230,24 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-os"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f08346c8deb39e96f86973da0e2d76cbb933d7ac9b750f6dc4daf955a6f997"
+dependencies = [
+ "gethostname",
+ "log",
+ "os_info",
+ "serde",
+ "serde_json",
+ "serialize-to-javascript",
+ "sys-locale",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "ak-meta",
  "ak-platform",
  "ak-platform-keyring",
+ "authentik-client",
  "serde",
  "serde_json",
  "tauri",

--- a/ak-agent-desktop/package.json
+++ b/ak-agent-desktop/package.json
@@ -18,6 +18,7 @@
         "@goauthentik/brand-assets": "^2.0.0",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-os": "~2.3.2",
         "lit": "^3.3.3"
     },
     "devDependencies": {

--- a/ak-agent-desktop/package.json
+++ b/ak-agent-desktop/package.json
@@ -14,6 +14,7 @@
     },
     "type": "module",
     "dependencies": {
+        "@goauthentik/api": "^2026.5.3",
         "@goauthentik/brand-assets": "^2.0.0",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
@@ -29,6 +30,8 @@
     },
     "prettier": "@goauthentik/prettier-config",
     "pnpm": {
-        "onlyBuiltDependencies": ["esbuild"]
+        "onlyBuiltDependencies": [
+            "esbuild"
+        ]
     }
 }

--- a/ak-agent-desktop/src-tauri/Cargo.toml
+++ b/ak-agent-desktop/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
+tauri-plugin-os = "2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"

--- a/ak-agent-desktop/src-tauri/Cargo.toml
+++ b/ak-agent-desktop/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ ak-agent = { path = "../../ak-agent" }
 ak-platform = { path = "../../ak-platform" }
 ak-platform-keyring = { path = "../../ak-platform-keyring" }
 ak-meta = { path = "../../ak-meta" }
+authentik-client = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/ak-agent-desktop/src-tauri/capabilities/default.json
+++ b/ak-agent-desktop/src-tauri/capabilities/default.json
@@ -3,5 +3,11 @@
     "identifier": "default",
     "description": "Capability for the main window",
     "windows": ["main"],
-    "permissions": ["core:default", "opener:default", "core:window:allow-start-dragging", "opener:allow-default-urls"]
+    "permissions": [
+        "core:default",
+        "opener:default",
+        "core:window:allow-start-dragging",
+        "opener:allow-default-urls",
+        "os:default"
+    ]
 }

--- a/ak-agent-desktop/src-tauri/src/cmd.rs
+++ b/ak-agent-desktop/src-tauri/src/cmd.rs
@@ -1,5 +1,6 @@
-use ak_agent::{Agent, token::AuthentikClaims};
+use ak_agent::Agent;
 use ak_platform::generated::agent_ctrl::Profile;
+use authentik_client::{apis::core_api::core_users_me_retrieve, models::SessionUser};
 
 pub type Result<T> = std::result::Result<T, String>;
 
@@ -27,16 +28,22 @@ pub async fn list_profiles(state: tauri::State<'_, Agent>) -> Result<Vec<Profile
 }
 
 #[tauri::command]
-pub async fn get_user_info(
-    profile: String,
-    state: tauri::State<'_, Agent>,
-) -> Result<AuthentikClaims> {
-    let ptm = state
-        .gtm
-        .for_profile(&profile)
+pub async fn get_user_info(profile: String, state: tauri::State<'_, Agent>) -> Result<SessionUser> {
+    let prof = state
+        .cfg
+        .read()
         .await
-        .ok_or_else(|| format!("profile '{profile}' not found"))?;
-    let token = ptm.token().await.map_err(|e| e.to_string())?;
-    let claims = token.claims().map_err(|e| e.to_string())?;
-    Ok(claims)
+        .profiles
+        .get(&profile)
+        .cloned()
+        .ok_or_else(|| "profile not found".to_string())?;
+    let me = core_users_me_retrieve(&prof.api_config().map_err(|e| e.to_string())?)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(me)
+}
+
+#[tauri::command]
+pub async fn active_profile(state: tauri::State<'_, Agent>) -> Result<String> {
+    Ok(state.cfg.read().await.active_profile.clone())
 }

--- a/ak-agent-desktop/src-tauri/src/cmd.rs
+++ b/ak-agent-desktop/src-tauri/src/cmd.rs
@@ -6,11 +6,18 @@ pub type Result<T> = std::result::Result<T, String>;
 
 #[tauri::command]
 pub async fn list_profiles(state: tauri::State<'_, Agent>) -> Result<Vec<Profile>> {
+    let snapshot: Vec<_> = {
+        let cfg = state.cfg.read().await;
+        cfg.profiles
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    };
     let mut profiles = vec![];
-    for (key, c_prof) in state.cfg.read().await.profiles.iter() {
+    for (key, c_prof) in snapshot {
         let ptm = state
             .gtm
-            .for_profile(key)
+            .for_profile(&key)
             .await
             .ok_or("profile not found")?;
         let token = ptm.token().await.map_err(|e| e.to_string())?;

--- a/ak-agent-desktop/src-tauri/src/lib.rs
+++ b/ak-agent-desktop/src-tauri/src/lib.rs
@@ -86,7 +86,8 @@ pub fn start_tauri() -> Result<()> {
         })
         .invoke_handler(tauri::generate_handler![
             cmd::get_user_info,
-            cmd::list_profiles
+            cmd::list_profiles,
+            cmd::active_profile,
         ])
         .build(tauri::generate_context!())?
         .run(|app, event| {

--- a/ak-agent-desktop/src-tauri/src/lib.rs
+++ b/ak-agent-desktop/src-tauri/src/lib.rs
@@ -32,6 +32,7 @@ pub fn run() {
 
 pub fn start_tauri() -> Result<()> {
     tauri::Builder::default()
+        .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
             ui::show_main(app);
         }))

--- a/ak-agent-desktop/src/bridge.ts
+++ b/ak-agent-desktop/src/bridge.ts
@@ -1,10 +1,6 @@
-import { invoke } from "@tauri-apps/api/core";
+import { SessionUser, SessionUserFromJSON } from '@goauthentik/api';
 
-export interface userInfo {
-    preferred_username: string;
-    email: string;
-    name: string;
-}
+import { invoke } from '@tauri-apps/api/core';
 
 export interface profile {
     name: string;
@@ -14,8 +10,9 @@ export interface profile {
     nextRenew: Date;
 }
 
-export async function userInfo(profile: String): Promise<userInfo> {
-    return await invoke<userInfo>("get_user_info", { profile: profile });
+export async function userInfo(profile: String): Promise<SessionUser> {
+    const rawUser =  await invoke<unknown>("get_user_info", { profile: profile });
+    return SessionUserFromJSON(rawUser);
 }
 
 export async function listProfiles(): Promise<profile[]> {

--- a/ak-agent-desktop/src/bridge.ts
+++ b/ak-agent-desktop/src/bridge.ts
@@ -1,6 +1,6 @@
-import { SessionUser, SessionUserFromJSON } from '@goauthentik/api';
+import { SessionUser, SessionUserFromJSON } from "@goauthentik/api";
 
-import { invoke } from '@tauri-apps/api/core';
+import { invoke } from "@tauri-apps/api/core";
 
 export interface profile {
     name: string;
@@ -11,8 +11,12 @@ export interface profile {
 }
 
 export async function userInfo(profile: String): Promise<SessionUser> {
-    const rawUser =  await invoke<unknown>("get_user_info", { profile: profile });
+    const rawUser = await invoke<unknown>("get_user_info", { profile: profile });
     return SessionUserFromJSON(rawUser);
+}
+
+export async function activeProfile(): Promise<string> {
+    return await invoke<string>("active_profile");
 }
 
 export async function listProfiles(): Promise<profile[]> {

--- a/ak-agent-desktop/src/elements/app-shell.ts
+++ b/ak-agent-desktop/src/elements/app-shell.ts
@@ -1,14 +1,15 @@
 import "./header.js";
 import "./profile-status.js";
 
-import { listProfiles, profile, userInfo } from "../bridge";
+import { activeProfile, listProfiles, profile, userInfo } from "../bridge";
 
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import { SessionUser } from "@goauthentik/api";
+
 import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 
 import { css, html, LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
-import { SessionUser } from "@goauthentik/api";
 
 @customElement("ak-app-shell")
 export class AppShell extends LitElement {
@@ -32,6 +33,9 @@ export class AppShell extends LitElement {
     @state()
     private profiles?: profile[];
 
+    @state()
+    private activeProfile?: string;
+
     private _unlisten?: () => void;
 
     async connectedCallback(): Promise<void> {
@@ -48,6 +52,7 @@ export class AppShell extends LitElement {
     private async _refresh(): Promise<void> {
         this.user = await userInfo("default");
         this.profiles = await listProfiles();
+        this.activeProfile = await activeProfile();
     }
 
     render() {
@@ -65,7 +70,10 @@ export class AppShell extends LitElement {
                 }}
             ></ak-platform-header>
             <div class="content">
-                <ak-profile-status .profiles=${this.profiles ?? []}></ak-profile-status>
+                <ak-profile-status
+                    .profiles=${this.profiles ?? []}
+                    .activeProfile=${this.activeProfile}
+                ></ak-profile-status>
             </div>
         `;
     }

--- a/ak-agent-desktop/src/elements/app-shell.ts
+++ b/ak-agent-desktop/src/elements/app-shell.ts
@@ -8,6 +8,7 @@ import { listen } from "@tauri-apps/api/event";
 
 import { css, html, LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import { SessionUser } from "@goauthentik/api";
 
 @customElement("ak-app-shell")
 export class AppShell extends LitElement {
@@ -26,7 +27,7 @@ export class AppShell extends LitElement {
     `;
 
     @state()
-    private user?: userInfo;
+    private user?: SessionUser;
 
     @state()
     private profiles?: profile[];

--- a/ak-agent-desktop/src/elements/app-shell.ts
+++ b/ak-agent-desktop/src/elements/app-shell.ts
@@ -50,9 +50,13 @@ export class AppShell extends LitElement {
     }
 
     private async _refresh(): Promise<void> {
-        this.user = await userInfo("default");
         this.profiles = await listProfiles();
         this.activeProfile = await activeProfile();
+        try {
+            this.user = await userInfo("default");
+        } catch (exc) {
+            console.warn("Failed to fetch user info", exc);
+        }
     }
 
     render() {

--- a/ak-agent-desktop/src/elements/header.ts
+++ b/ak-agent-desktop/src/elements/header.ts
@@ -1,6 +1,7 @@
 import { SessionUser } from "@goauthentik/api";
-
 import logoSvg from "@goauthentik/brand-assets/icon_left_brand_white.svg?raw";
+
+import { platform } from "@tauri-apps/plugin-os";
 
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators.js";
@@ -17,10 +18,10 @@ export class Header extends LitElement {
             background: var(--ak-color-brand);
         }
         .header {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
+            display: flex;
+            justify-content: space-between;
             align-items: center;
-            padding: 0 16px 0 0;
+            padding: 0 16px;
             height: 52px;
             cursor: default;
             user-select: none;
@@ -30,14 +31,39 @@ export class Header extends LitElement {
             align-items: center;
             justify-content: center;
         }
+        .logo[data-platform="macos"] {
+            padding-left: 4.5rem;
+        }
         .logo svg {
             height: 26px;
             width: auto;
+        }
+        .actions {
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+        }
+        .avatar {
+            width: 32px;
+            height: 32px;
+            border-radius: 50%;
+            background: rgba(255, 255, 255, 0.2);
+            color: #fff;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 13px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            cursor: pointer;
+            user-select: none;
         }
     `;
 
     private _startDrag(e: MouseEvent) {
         if (e.button !== 0) return;
+        const target = e.composedPath()[0] as HTMLElement;
+        if (target.closest?.("button, a, .avatar")) return;
         void import("@tauri-apps/api/window")
             .then(({ getCurrentWindow }) => void getCurrentWindow().startDragging())
             .catch(() => {
@@ -48,7 +74,10 @@ export class Header extends LitElement {
     render() {
         return html`
             <div class="header" @mousedown=${this._startDrag}>
-                <div class="logo">${unsafeHTML(logoSvg)}</div>
+                <div class="logo" data-platform="${platform()}">${unsafeHTML(logoSvg)}</div>
+                <div class="actions">
+                    <img class="avatar" src="${this.user?.user.avatar || ""}" />
+                </div>
             </div>
         `;
     }

--- a/ak-agent-desktop/src/elements/header.ts
+++ b/ak-agent-desktop/src/elements/header.ts
@@ -1,4 +1,4 @@
-import type { userInfo } from "../bridge.js";
+import { SessionUser } from "@goauthentik/api";
 
 import logoSvg from "@goauthentik/brand-assets/icon_left_brand_white.svg?raw";
 
@@ -8,7 +8,9 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 @customElement("ak-platform-header")
 export class Header extends LitElement {
-    @property({ type: Object }) user?: userInfo;
+    @property({ type: Object })
+    user?: SessionUser;
+
     static styles = css`
         :host {
             display: block;

--- a/ak-agent-desktop/src/elements/profile-status.ts
+++ b/ak-agent-desktop/src/elements/profile-status.ts
@@ -2,7 +2,7 @@ import type { profile } from "../bridge.js";
 
 import { openUrl } from "@tauri-apps/plugin-opener";
 
-import { css, html, LitElement } from "lit";
+import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 type RenewalStatus = "active" | "expiring" | "expired" | "disconnected";
@@ -18,7 +18,7 @@ function renewalStatus(nextRenew: Date | string | null): RenewalStatus {
 }
 
 const STATUS_LABELS: Record<RenewalStatus, string> = {
-    active: "Active",
+    active: "Valid",
     expiring: "Expiring soon",
     expired: "Needs renewal",
     disconnected: "Not connected",
@@ -127,6 +127,7 @@ export class ProfileStatus extends LitElement {
     `;
 
     @property({ type: Array }) profiles: profile[] = [];
+    @property() activeProfile?: string;
 
     render() {
         return html`
@@ -140,6 +141,13 @@ export class ProfileStatus extends LitElement {
                               <div class="profile-row">
                                   <div class="profile-header">
                                       <span class="profile-name">${p.name}</span>
+                                      ${p.name === this.activeProfile
+                                          ? html`
+                                                <span class="status-badge active"
+                                                    >Active Profile</span
+                                                >
+                                            `
+                                          : nothing}
                                       <span class="status-badge ${status}"
                                           >${STATUS_LABELS[status]}</span
                                       >

--- a/ak-agent-desktop/src/elements/profile-status.ts
+++ b/ak-agent-desktop/src/elements/profile-status.ts
@@ -141,16 +141,18 @@ export class ProfileStatus extends LitElement {
                               <div class="profile-row">
                                   <div class="profile-header">
                                       <span class="profile-name">${p.name}</span>
-                                      ${p.name === this.activeProfile
-                                          ? html`
-                                                <span class="status-badge active"
-                                                    >Active Profile</span
-                                                >
-                                            `
-                                          : nothing}
-                                      <span class="status-badge ${status}"
-                                          >${STATUS_LABELS[status]}</span
-                                      >
+                                      <div class="status-container">
+                                          ${p.name === this.activeProfile
+                                              ? html`
+                                                    <span class="status-badge active"
+                                                        >Active Profile</span
+                                                    >
+                                                `
+                                              : nothing}
+                                          <span class="status-badge ${status}"
+                                              >${STATUS_LABELS[status]}</span
+                                          >
+                                      </div>
                                   </div>
                                   <div class="profile-username">Username: ${p.username}</div>
                                   <div class="profile-url">

--- a/ak-agent/src/config/mod.rs
+++ b/ak-agent/src/config/mod.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, fmt::Debug};
 
 use ak_meta::user_agent;
 use ak_platform::log::LevelFilter;
+use ak_platform::paths::DEFAULT_PROFILE;
 use ak_platform::storage::cfgmgr::schema::Config;
 use ak_platform::{log::set_log_level, prelude::*};
 use ak_platform_keyring;
@@ -9,10 +10,22 @@ use authentik_client::apis::configuration::Configuration;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ConfigV1 {
     pub debug: bool,
+    #[serde(default)]
+    pub active_profile: String,
     pub profiles: HashMap<String, ConfigV1Profile>,
+}
+
+impl Default for ConfigV1 {
+    fn default() -> Self {
+        Self {
+            debug: false,
+            active_profile: DEFAULT_PROFILE.to_string(),
+            profiles: Default::default(),
+        }
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/ak-agent/src/config/mod.rs
+++ b/ak-agent/src/config/mod.rs
@@ -10,7 +10,7 @@ use authentik_client::apis::configuration::Configuration;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConfigV1 {
     pub debug: bool,
     #[serde(default)]

--- a/ak-agent/src/grpc/agent_ctrl.rs
+++ b/ak-agent/src/grpc/agent_ctrl.rs
@@ -62,6 +62,9 @@ impl AgentCtrl for AgentGRPCServer {
                     req.refresh_token,
                 ),
             );
+            if cfg.active_profile.is_empty() {
+                cfg.active_profile = profile_name.clone();
+            }
         }
         if let Err(e) = self.agent.cfg.save().await {
             tracing::warn!("failed to save config: {e:?}");

--- a/ak-agent/src/grpc/agent_ctrl.rs
+++ b/ak-agent/src/grpc/agent_ctrl.rs
@@ -1,7 +1,8 @@
 use ak_platform::generated::{
-    agent::ResponseHeader,
+    agent::{RequestHeader, ResponseHeader},
     agent_ctrl::{
-        ListProfilesResponse, Profile, SetupRequest, SetupResponse, agent_ctrl_server::AgentCtrl,
+        CurrentProfileResponse, ListProfilesResponse, Profile, SetupRequest, SetupResponse,
+        agent_ctrl_server::AgentCtrl,
     },
 };
 use tonic::{Request, Response, Status};
@@ -70,6 +71,32 @@ impl AgentCtrl for AgentGRPCServer {
         tracing::info!(profile = profile_name, "setup new profile");
         Ok(Response::new(SetupResponse {
             header: Some(ResponseHeader { successful: true }),
+        }))
+    }
+
+    async fn switch_profile(
+        &self,
+        request: Request<RequestHeader>,
+    ) -> Result<Response<ResponseHeader>, Status> {
+        let new_profile = request.into_inner().profile;
+        let mut cfg = self.agent.cfg.write().await;
+        cfg.active_profile = new_profile.clone();
+        if let Err(e) = self.agent.cfg.save().await {
+            tracing::warn!("failed to save config: {e:?}");
+            return Err(Status::from_error(e));
+        }
+        tracing::debug!(profile = new_profile, "Switched active profile");
+        Ok(Response::new(ResponseHeader { successful: true }))
+    }
+
+    async fn current_profile(
+        &self,
+        _request: Request<()>,
+    ) -> Result<Response<CurrentProfileResponse>, Status> {
+        let cfg = self.agent.cfg.read().await;
+        Ok(Response::new(CurrentProfileResponse {
+            header: Some(ResponseHeader { successful: true }),
+            profile: cfg.active_profile.clone(),
         }))
     }
 }

--- a/ak-agent/src/grpc/agent_ctrl.rs
+++ b/ak-agent/src/grpc/agent_ctrl.rs
@@ -79,8 +79,10 @@ impl AgentCtrl for AgentGRPCServer {
         request: Request<RequestHeader>,
     ) -> Result<Response<ResponseHeader>, Status> {
         let new_profile = request.into_inner().profile;
-        let mut cfg = self.agent.cfg.write().await;
-        cfg.active_profile = new_profile.clone();
+        {
+            let mut cfg = self.agent.cfg.write().await;
+            cfg.active_profile = new_profile.clone();
+        }
         if let Err(e) = self.agent.cfg.save().await {
             tracing::warn!("failed to save config: {e:?}");
             return Err(Status::from_error(e));

--- a/ak-agent/src/ssh/mod.rs
+++ b/ak-agent/src/ssh/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::Agent;
 use ak_platform::{
     net::server::{ConnectedLocalStream, ListenerStream, SocketPermMode, listen},
-    paths::{AgentSocketID, DEFAULT_PROFILE, agent_socket_path},
+    paths::{AgentSocketID, agent_socket_path},
     prelude::*,
 };
 use ssh_agent_lib::agent::{Session, listen as ssh_listen};
@@ -23,7 +23,6 @@ use uuid::Uuid;
 pub struct AgentSSHServer {
     agent: Arc<Agent>,
     priv_key: Arc<PrivateKey>,
-    profile: String,
 }
 
 impl ssh_agent_lib::agent::Agent<ListenerStream> for AgentSSHServer {
@@ -31,7 +30,6 @@ impl ssh_agent_lib::agent::Agent<ListenerStream> for AgentSSHServer {
         SSHAgentTransaction {
             agent: Arc::clone(&self.agent),
             priv_key: Arc::clone(&self.priv_key),
-            profile: self.profile.clone(),
             creds: socket.connect_info(),
             host_key: None,
             session_id: None,
@@ -45,21 +43,9 @@ impl AgentSSHServer {
     pub async fn new(agent: Arc<Agent>) -> Result<Self> {
         let priv_key = PrivateKey::random(&mut OsRng, Algorithm::Ed25519)
             .map_err(|e| -> BoxError { Box::from(e.to_string()) })?;
-
-        let profile = agent
-            .cfg
-            .read()
-            .await
-            .profiles
-            .keys()
-            .next()
-            .cloned()
-            .unwrap_or(DEFAULT_PROFILE.into());
-
         Ok(AgentSSHServer {
             agent,
             priv_key: Arc::new(priv_key),
-            profile,
         })
     }
 

--- a/ak-agent/src/ssh/txn.rs
+++ b/ak-agent/src/ssh/txn.rs
@@ -13,7 +13,6 @@ use crate::ssh::txn_keys::generate_cert;
 pub struct SSHAgentTransaction {
     pub agent: Arc<Agent>,
     pub priv_key: Arc<PrivateKey>,
-    pub profile: String,
     pub creds: ProcCredentials,
     pub host_key: Option<KeyData>,
     pub session_id: Option<Vec<u8>>,
@@ -35,11 +34,12 @@ impl SSHAgentTransaction {
             }
         };
 
-        let token_mgr = match self.agent.gtm.for_profile(&self.profile).await {
+        let profile = self.agent.cfg.read().await.active_profile.clone();
+        let token_mgr = match self.agent.gtm.for_profile(profile.clone()).await {
             Some(m) => m,
             None => {
                 tracing::warn!(
-                    profile = self.profile,
+                    profile = profile,
                     "ssh-agent: ensure_cert: profile not found"
                 );
                 return None;
@@ -97,10 +97,11 @@ impl SSHAgentTransaction {
 
     async fn get_host_token(&self, host_key: &KeyData) -> Result<(String, i64)> {
         let profile = {
+            let profile = self.agent.cfg.read().await.active_profile.clone();
             let cfg = self.agent.cfg.read().await;
             cfg.profiles
-                .get(&self.profile)
-                .ok_or("profile not found")?
+                .get(&profile)
+                .ok_or(format!("profile {} not found", profile))?
                 .clone()
         };
 

--- a/ak-agent/src/token/global.rs
+++ b/ak-agent/src/token/global.rs
@@ -114,8 +114,8 @@ impl GlobalTokenManager {
         }
     }
 
-    pub async fn for_profile(&self, name: &str) -> Option<Arc<ProfileTokenManager>> {
-        self.managers.read().await.get(name).cloned()
+    pub async fn for_profile<T: ToString>(&self, name: T) -> Option<Arc<ProfileTokenManager>> {
+        self.managers.read().await.get(&name.to_string()).cloned()
     }
 }
 

--- a/ak-cli/src/api.rs
+++ b/ak-cli/src/api.rs
@@ -11,7 +11,7 @@ use authentik_client::apis::configuration::Configuration;
 include!(concat!(env!("OUT_DIR"), "/api_commands.rs"));
 
 pub async fn exec_api_command(app: super::App, cmd: &ApiCommand) -> Result<(), BoxError> {
-    let profile = app.clone().args.profile;
+    let profile = app.profile();
     let res = app
         .user()
         .await?

--- a/ak-cli/src/commands/auth.rs
+++ b/ak-cli/src/commands/auth.rs
@@ -32,7 +32,7 @@ pub async fn raw(app: App, client_id: &str) -> Result<()> {
     let creds = raw::get_credentials(
         app.clone().user().await?,
         raw::CredentialsOpts {
-            profile: app.args.profile.clone(),
+            profile: app.profile(),
             client_id: client_id.to_owned(),
         },
     )
@@ -45,7 +45,7 @@ pub async fn aws(app: App, client_id: &str, role_arn: &str, region: &str) -> Res
     let creds = aws::get_credentials(
         app.clone().user().await?,
         aws::CredentialsOpts {
-            profile: app.args.profile.clone(),
+            profile: app.profile(),
             client_id: client_id.to_owned(),
             role_arn: role_arn.to_owned(),
             region: region.to_owned(),
@@ -60,7 +60,7 @@ pub async fn kubectl(app: App, client_id: &str) -> Result<()> {
     let creds = k8s::get_credentials(
         app.clone().user().await?,
         k8s::CredentialsOpts {
-            profile: app.args.profile.clone(),
+            profile: app.profile(),
             client_id: client_id.to_owned(),
         },
     )

--- a/ak-cli/src/commands/config.rs
+++ b/ak-cli/src/commands/config.rs
@@ -105,7 +105,7 @@ pub async fn setup(app: App, authentik_url: &str, client_id: &str, app_slug: &st
     Ok(())
 }
 
-pub async fn current_profile(app: App) -> Result<String> {
+pub async fn current_profile(app: App) -> Result<()> {
     let res = app
         .user()
         .await?
@@ -115,7 +115,8 @@ pub async fn current_profile(app: App) -> Result<String> {
         .await?
         .into_inner();
     assert_response_valid(res.header)?;
-    Ok(res.profile)
+    println!("{}", res.profile);
+    Ok(())
 }
 
 pub async fn switch_profile(app: App, profile: &str) -> Result<()> {
@@ -130,5 +131,6 @@ pub async fn switch_profile(app: App, profile: &str) -> Result<()> {
         .await?
         .into_inner();
     assert_response_valid(Some(res))?;
+    println!("Successfully switched to profile '{profile}'!");
     Ok(())
 }

--- a/ak-cli/src/commands/config.rs
+++ b/ak-cli/src/commands/config.rs
@@ -104,3 +104,31 @@ pub async fn setup(app: App, authentik_url: &str, client_id: &str, app_slug: &st
 
     Ok(())
 }
+
+pub async fn current_profile(app: App, profile: &str) -> Result<()> {
+    let res = app
+        .user()
+        .await?
+        .clone()
+        .ctrl()
+        .current_profile(())
+        .await?
+        .into_inner();
+    assert_response_valid(Some(res))?;
+    Ok(())
+}
+
+pub async fn switch_profile(app: App, profile: &str) -> Result<()> {
+    let res = app
+        .user()
+        .await?
+        .clone()
+        .ctrl()
+        .switch_profile(RequestHeader {
+            profile: profile.to_string(),
+        })
+        .await?
+        .into_inner();
+    assert_response_valid(Some(res))?;
+    Ok(())
+}

--- a/ak-cli/src/commands/config.rs
+++ b/ak-cli/src/commands/config.rs
@@ -64,7 +64,7 @@ pub async fn setup(app: App, authentik_url: &str, client_id: &str, app_slug: &st
         refresh_token = rt;
     } else {
         let prof = setup::setup(setup::Options {
-            profile_name: app.args.profile.clone(),
+            profile_name: app.args.profile.clone().unwrap_or(app.profile()),
             authentik_url: Url::parse(authentik_url)?,
             app_slug: app_slug.to_owned(),
             client_id: client_id.to_owned(),
@@ -90,7 +90,7 @@ pub async fn setup(app: App, authentik_url: &str, client_id: &str, app_slug: &st
         .ctrl()
         .setup(SetupRequest {
             header: Some(RequestHeader {
-                profile: app.args.profile.clone(),
+                profile: app.args.profile.clone().unwrap_or(app.profile()),
             }),
             authentik_url: authentik_url.to_owned(),
             app_slug: app_slug.to_owned(),
@@ -105,7 +105,7 @@ pub async fn setup(app: App, authentik_url: &str, client_id: &str, app_slug: &st
     Ok(())
 }
 
-pub async fn current_profile(app: App, profile: &str) -> Result<()> {
+pub async fn current_profile(app: App) -> Result<String> {
     let res = app
         .user()
         .await?
@@ -114,8 +114,8 @@ pub async fn current_profile(app: App, profile: &str) -> Result<()> {
         .current_profile(())
         .await?
         .into_inner();
-    assert_response_valid(Some(res))?;
-    Ok(())
+    assert_response_valid(res.header)?;
+    Ok(res.profile)
 }
 
 pub async fn switch_profile(app: App, profile: &str) -> Result<()> {

--- a/ak-cli/src/commands/whoami.rs
+++ b/ak-cli/src/commands/whoami.rs
@@ -13,7 +13,7 @@ pub async fn whoami(app: App) -> Result<()> {
         .auth()
         .who_am_i(WhoAmIRequest {
             header: Some(RequestHeader {
-                profile: app.args.profile.clone(),
+                profile: app.profile(),
             }),
         })
         .await?

--- a/ak-cli/src/main.rs
+++ b/ak-cli/src/main.rs
@@ -102,7 +102,14 @@ impl App {
             return p.clone();
         }
         let cp: Result<String> = async {
-            let res = self.clone().user().await?.ctrl().current_profile(()).await?.into_inner();
+            let res = self
+                .clone()
+                .user()
+                .await?
+                .ctrl()
+                .current_profile(())
+                .await?
+                .into_inner();
             assert_response_valid(res.header)?;
             Ok(res.profile)
         }

--- a/ak-cli/src/main.rs
+++ b/ak-cli/src/main.rs
@@ -49,6 +49,11 @@ enum Commands {
     Whoami,
     /// Version of authentik Agent components
     Version,
+    /// Switch to a different active profile
+    SwitchProfile {
+        #[arg(short, long, required = true)]
+        profile: String,
+    },
 
     /// Configure authentik CLI
     Config {
@@ -104,6 +109,7 @@ async fn main() -> std::result::Result<(), Error> {
         Commands::Completions { shell } => commands::completions::completions(*shell).await,
         Commands::Whoami => commands::whoami::whoami(app).await,
         Commands::Version => commands::version::version(app).await,
+        Commands::SwitchProfile { profile } => commands::config::switch_profile(app, profile).await,
         Commands::Config { command } => match command {
             ConfigCommands::ListProfiles => commands::config::list_profiles(app).await,
             ConfigCommands::Setup {

--- a/ak-cli/src/main.rs
+++ b/ak-cli/src/main.rs
@@ -45,8 +45,9 @@ enum Commands {
     /// Version of authentik Agent components
     Version,
     /// Switch to a different active profile
+    #[command(alias = "s")]
     SwitchProfile {
-        #[arg(short, long, required = true)]
+        #[arg(required = true)]
         profile: String,
     },
 

--- a/ak-cli/src/main.rs
+++ b/ak-cli/src/main.rs
@@ -1,4 +1,5 @@
 use crate::commands::{auth::AuthCommands, config::ConfigCommands};
+use ak_platform::grpc::assert_response_valid;
 use ak_platform::log::LevelFilter;
 use ak_platform::paths::DEFAULT_PROFILE;
 use ak_platform::prelude::*;
@@ -21,26 +22,20 @@ pub mod setup;
 #[command(about, long_about = None)]
 pub struct CliArgs {
     /// Enable debug logging
-    #[arg(short, long, default_value_t = false)]
+    #[arg(short, long, default_value_t = false, global = true)]
     verbose: bool,
     /// Output JSON data
-    #[arg(short, long, default_value_t = false)]
+    #[arg(short, long, default_value_t = false, global = true)]
     json: bool,
     /// A name for the profile
-    #[arg(short, long, default_value = DEFAULT_PROFILE)]
-    profile: String,
+    #[arg(short, long, global = true)]
+    profile: Option<String>,
     /// Socket the agent is listening on
-    #[arg(short, long)]
+    #[arg(short, long, global = true)]
     socket: Option<String>,
 
     #[command(subcommand)]
     command: Commands,
-}
-
-#[derive(Clone)]
-pub struct App {
-    args: CliArgs,
-    client: Option<Client<AnyService>>,
 }
 
 #[derive(Subcommand, Clone)]
@@ -77,15 +72,56 @@ enum Commands {
     },
 }
 
+#[derive(Clone)]
+pub struct App {
+    args: CliArgs,
+    client: Option<Client<AnyService>>,
+    active_profile: String,
+}
+
 impl App {
-    pub async fn user(mut self) -> Result<Client<AnyService>> {
+    pub async fn new(args: CliArgs) -> Self {
+        let mut app = App {
+            args,
+            client: None,
+            active_profile: "".to_string(),
+        };
+        let active_profile = app.lookup_profile().await;
+        app.active_profile = active_profile;
+        app
+    }
+
+    pub fn profile(&self) -> String {
+        self.active_profile.clone()
+    }
+
+    async fn lookup_profile(&self) -> String {
+        if let Some(p) = &self.args.profile {
+            tracing::debug!(profile = p, "Using argument-specified profile");
+            return p.clone();
+        }
+        let cp: Result<String> = async {
+            let res = self.clone().user().await?.ctrl().current_profile(()).await?.into_inner();
+            assert_response_valid(res.header)?;
+            Ok(res.profile)
+        }
+        .await;
+        match cp {
+            Ok(p) => {
+                tracing::debug!(profile = p, "Using currently selected profile");
+                p
+            }
+            Err(e) => {
+                tracing::warn!("failed to get profile from agent: {e:?}");
+                DEFAULT_PROFILE.to_string()
+            }
+        }
+    }
+
+    pub async fn user(self) -> Result<Client<AnyService>> {
         match self.client {
             Some(c) => Ok(c),
-            None => {
-                let c = Client::new(self.args.socket).await?;
-                self.client = Some(c.clone());
-                Ok(c)
-            }
+            None => Ok(Client::new(self.args.socket).await?),
         }
     }
 }
@@ -100,10 +136,7 @@ async fn main() -> std::result::Result<(), Error> {
         set_log_level(LevelFilter::Trace);
     }
 
-    let app = App {
-        args: cli.clone(),
-        client: None,
-    };
+    let app = App::new(cli.clone()).await;
 
     let res = match &cli.command {
         Commands::Completions { shell } => commands::completions::completions(*shell).await,

--- a/ak-platform/src/generated/agent_ctrl/agent_ctrl.rs
+++ b/ak-platform/src/generated/agent_ctrl/agent_ctrl.rs
@@ -40,6 +40,13 @@ pub struct ListProfilesResponse {
     #[prost(message, repeated, tag="2")]
     pub profiles: ::prost::alloc::vec::Vec<Profile>,
 }
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct CurrentProfileResponse {
+    #[prost(message, optional, tag="1")]
+    pub header: ::core::option::Option<super::agent::ResponseHeader>,
+    #[prost(string, tag="2")]
+    pub profile: ::prost::alloc::string::String,
+}
 include!("agent_ctrl.tonic.rs");
 include!("agent_ctrl.serde.rs");
 // @@protoc_insertion_point(module)

--- a/ak-platform/src/generated/agent_ctrl/agent_ctrl.serde.rs
+++ b/ak-platform/src/generated/agent_ctrl/agent_ctrl.serde.rs
@@ -1,4 +1,112 @@
 // @generated
+impl serde::Serialize for CurrentProfileResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.header.is_some() {
+            len += 1;
+        }
+        if !self.profile.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("agent_ctrl.CurrentProfileResponse", len)?;
+        if let Some(v) = self.header.as_ref() {
+            struct_ser.serialize_field("header", v)?;
+        }
+        if !self.profile.is_empty() {
+            struct_ser.serialize_field("profile", &self.profile)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for CurrentProfileResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "header",
+            "profile",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Header,
+            Profile,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "header" => Ok(GeneratedField::Header),
+                            "profile" => Ok(GeneratedField::Profile),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = CurrentProfileResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct agent_ctrl.CurrentProfileResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<CurrentProfileResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut header__ = None;
+                let mut profile__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Header => {
+                            if header__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("header"));
+                            }
+                            header__ = map_.next_value()?;
+                        }
+                        GeneratedField::Profile => {
+                            if profile__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("profile"));
+                            }
+                            profile__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(CurrentProfileResponse {
+                    header: header__,
+                    profile: profile__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("agent_ctrl.CurrentProfileResponse", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for ListProfilesResponse {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/ak-platform/src/generated/agent_ctrl/agent_ctrl.tonic.rs
+++ b/ak-platform/src/generated/agent_ctrl/agent_ctrl.tonic.rs
@@ -135,6 +135,54 @@ pub mod agent_ctrl_client {
                 .insert(GrpcMethod::new("agent_ctrl.AgentCtrl", "Setup"));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn switch_profile(
+            &mut self,
+            request: impl tonic::IntoRequest<super::super::agent::RequestHeader>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::agent::ResponseHeader>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/agent_ctrl.AgentCtrl/SwitchProfile",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("agent_ctrl.AgentCtrl", "SwitchProfile"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn current_profile(
+            &mut self,
+            request: impl tonic::IntoRequest<()>,
+        ) -> std::result::Result<
+            tonic::Response<super::CurrentProfileResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/agent_ctrl.AgentCtrl/CurrentProfile",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("agent_ctrl.AgentCtrl", "CurrentProfile"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -161,6 +209,20 @@ pub mod agent_ctrl_server {
             &self,
             request: tonic::Request<super::SetupRequest>,
         ) -> std::result::Result<tonic::Response<super::SetupResponse>, tonic::Status>;
+        async fn switch_profile(
+            &self,
+            request: tonic::Request<super::super::agent::RequestHeader>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::agent::ResponseHeader>,
+            tonic::Status,
+        >;
+        async fn current_profile(
+            &self,
+            request: tonic::Request<()>,
+        ) -> std::result::Result<
+            tonic::Response<super::CurrentProfileResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct AgentCtrlServer<T> {
@@ -306,6 +368,91 @@ pub mod agent_ctrl_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = SetupSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/agent_ctrl.AgentCtrl/SwitchProfile" => {
+                    #[allow(non_camel_case_types)]
+                    struct SwitchProfileSvc<T: AgentCtrl>(pub Arc<T>);
+                    impl<
+                        T: AgentCtrl,
+                    > tonic::server::UnaryService<super::super::agent::RequestHeader>
+                    for SwitchProfileSvc<T> {
+                        type Response = super::super::agent::ResponseHeader;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::super::agent::RequestHeader>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as AgentCtrl>::switch_profile(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = SwitchProfileSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/agent_ctrl.AgentCtrl/CurrentProfile" => {
+                    #[allow(non_camel_case_types)]
+                    struct CurrentProfileSvc<T: AgentCtrl>(pub Arc<T>);
+                    impl<T: AgentCtrl> tonic::server::UnaryService<()>
+                    for CurrentProfileSvc<T> {
+                        type Response = super::CurrentProfileResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(&mut self, request: tonic::Request<()>) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as AgentCtrl>::current_profile(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = CurrentProfileSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/ak-platform/src/storage/cfgmgr/mod.rs
+++ b/ak-platform/src/storage/cfgmgr/mod.rs
@@ -101,8 +101,8 @@ where
 
     #[tracing::instrument]
     pub async fn save(&self) -> Result<()> {
-        let loaded = self.loaded.read().await;
-        loaded.pre_save().await?;
+        let snapshot = self.loaded.read().await.clone();
+        snapshot.pre_save().await?;
         tracing::debug!("saving config");
         let mut opts = OpenOptions::new();
         opts.create(true).truncate(true).read(true).write(true);
@@ -111,7 +111,7 @@ where
             opts.mode(0o600);
         }
         let file = opts.open(self.path.clone())?;
-        serde_json::to_writer(file, &*loaded)?;
+        serde_json::to_writer(file, &snapshot)?;
         self.notify_reload();
         Ok(())
     }

--- a/ak-platform/src/storage/cfgmgr/schema.rs
+++ b/ak-platform/src/storage/cfgmgr/schema.rs
@@ -4,7 +4,7 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use crate::prelude::*;
 
-pub trait Config: Default + Serialize + DeserializeOwned + Sized + Sync + Send + Debug {
+pub trait Config: Default + Serialize + DeserializeOwned + Sized + Sync + Send + Debug + Clone {
     fn post_load(&mut self) -> impl Future<Output = Result<()>> + Send {
         async { Ok(()) }
     }

--- a/ee/psso/Bridge/Generated/agent_ctrl.grpc.swift
+++ b/ee/psso/Bridge/Generated/agent_ctrl.grpc.swift
@@ -47,10 +47,38 @@ internal enum AgentCtrl: Sendable {
                 type: .unary
             )
         }
+        /// Namespace for "SwitchProfile" metadata.
+        internal enum SwitchProfile: Sendable {
+            /// Request type for "SwitchProfile".
+            internal typealias Input = RequestHeader
+            /// Response type for "SwitchProfile".
+            internal typealias Output = ResponseHeader
+            /// Descriptor for "SwitchProfile".
+            internal static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "agent_ctrl.AgentCtrl"),
+                method: "SwitchProfile",
+                type: .unary
+            )
+        }
+        /// Namespace for "CurrentProfile" metadata.
+        internal enum CurrentProfile: Sendable {
+            /// Request type for "CurrentProfile".
+            internal typealias Input = SwiftProtobuf.Google_Protobuf_Empty
+            /// Response type for "CurrentProfile".
+            internal typealias Output = CurrentProfileResponse
+            /// Descriptor for "CurrentProfile".
+            internal static let descriptor = GRPCCore.MethodDescriptor(
+                service: GRPCCore.ServiceDescriptor(fullyQualifiedService: "agent_ctrl.AgentCtrl"),
+                method: "CurrentProfile",
+                type: .unary
+            )
+        }
         /// Descriptors for all methods in the "agent_ctrl.AgentCtrl" service.
         internal static let descriptors: [GRPCCore.MethodDescriptor] = [
             ListProfiles.descriptor,
-            Setup.descriptor
+            Setup.descriptor,
+            SwitchProfile.descriptor,
+            CurrentProfile.descriptor
         ]
     }
 }
@@ -106,6 +134,44 @@ extension AgentCtrl {
             deserializer: some GRPCCore.MessageDeserializer<SetupResponse>,
             options: GRPCCore.CallOptions,
             onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<SetupResponse>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "SwitchProfile" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `RequestHeader` message.
+        ///   - serializer: A serializer for `RequestHeader` messages.
+        ///   - deserializer: A deserializer for `ResponseHeader` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func switchProfile<Result>(
+            request: GRPCCore.ClientRequest<RequestHeader>,
+            serializer: some GRPCCore.MessageSerializer<RequestHeader>,
+            deserializer: some GRPCCore.MessageDeserializer<ResponseHeader>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<ResponseHeader>) async throws -> Result
+        ) async throws -> Result where Result: Sendable
+
+        /// Call the "CurrentProfile" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `SwiftProtobuf.Google_Protobuf_Empty` message.
+        ///   - serializer: A serializer for `SwiftProtobuf.Google_Protobuf_Empty` messages.
+        ///   - deserializer: A deserializer for `CurrentProfileResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        func currentProfile<Result>(
+            request: GRPCCore.ClientRequest<SwiftProtobuf.Google_Protobuf_Empty>,
+            serializer: some GRPCCore.MessageSerializer<SwiftProtobuf.Google_Protobuf_Empty>,
+            deserializer: some GRPCCore.MessageDeserializer<CurrentProfileResponse>,
+            options: GRPCCore.CallOptions,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<CurrentProfileResponse>) async throws -> Result
         ) async throws -> Result where Result: Sendable
     }
 
@@ -184,6 +250,66 @@ extension AgentCtrl {
                 onResponse: handleResponse
             )
         }
+
+        /// Call the "SwitchProfile" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `RequestHeader` message.
+        ///   - serializer: A serializer for `RequestHeader` messages.
+        ///   - deserializer: A deserializer for `ResponseHeader` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        internal func switchProfile<Result>(
+            request: GRPCCore.ClientRequest<RequestHeader>,
+            serializer: some GRPCCore.MessageSerializer<RequestHeader>,
+            deserializer: some GRPCCore.MessageDeserializer<ResponseHeader>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<ResponseHeader>) async throws -> Result = { response in
+                try response.message
+            }
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.unary(
+                request: request,
+                descriptor: AgentCtrl.Method.SwitchProfile.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
+
+        /// Call the "CurrentProfile" method.
+        ///
+        /// - Parameters:
+        ///   - request: A request containing a single `SwiftProtobuf.Google_Protobuf_Empty` message.
+        ///   - serializer: A serializer for `SwiftProtobuf.Google_Protobuf_Empty` messages.
+        ///   - deserializer: A deserializer for `CurrentProfileResponse` messages.
+        ///   - options: Options to apply to this RPC.
+        ///   - handleResponse: A closure which handles the response, the result of which is
+        ///       returned to the caller. Returning from the closure will cancel the RPC if it
+        ///       hasn't already finished.
+        /// - Returns: The result of `handleResponse`.
+        internal func currentProfile<Result>(
+            request: GRPCCore.ClientRequest<SwiftProtobuf.Google_Protobuf_Empty>,
+            serializer: some GRPCCore.MessageSerializer<SwiftProtobuf.Google_Protobuf_Empty>,
+            deserializer: some GRPCCore.MessageDeserializer<CurrentProfileResponse>,
+            options: GRPCCore.CallOptions = .defaults,
+            onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<CurrentProfileResponse>) async throws -> Result = { response in
+                try response.message
+            }
+        ) async throws -> Result where Result: Sendable {
+            try await self.client.unary(
+                request: request,
+                descriptor: AgentCtrl.Method.CurrentProfile.descriptor,
+                serializer: serializer,
+                deserializer: deserializer,
+                options: options,
+                onResponse: handleResponse
+            )
+        }
     }
 }
 
@@ -235,6 +361,56 @@ extension AgentCtrl.ClientProtocol {
             request: request,
             serializer: GRPCProtobuf.ProtobufSerializer<SetupRequest>(),
             deserializer: GRPCProtobuf.ProtobufDeserializer<SetupResponse>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "SwitchProfile" method.
+    ///
+    /// - Parameters:
+    ///   - request: A request containing a single `RequestHeader` message.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    internal func switchProfile<Result>(
+        request: GRPCCore.ClientRequest<RequestHeader>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<ResponseHeader>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        try await self.switchProfile(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<RequestHeader>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<ResponseHeader>(),
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "CurrentProfile" method.
+    ///
+    /// - Parameters:
+    ///   - request: A request containing a single `SwiftProtobuf.Google_Protobuf_Empty` message.
+    ///   - options: Options to apply to this RPC.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    internal func currentProfile<Result>(
+        request: GRPCCore.ClientRequest<SwiftProtobuf.Google_Protobuf_Empty>,
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<CurrentProfileResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        try await self.currentProfile(
+            request: request,
+            serializer: GRPCProtobuf.ProtobufSerializer<SwiftProtobuf.Google_Protobuf_Empty>(),
+            deserializer: GRPCProtobuf.ProtobufDeserializer<CurrentProfileResponse>(),
             options: options,
             onResponse: handleResponse
         )
@@ -296,6 +472,64 @@ extension AgentCtrl.ClientProtocol {
             metadata: metadata
         )
         return try await self.setup(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "SwitchProfile" method.
+    ///
+    /// - Parameters:
+    ///   - message: request message to send.
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    internal func switchProfile<Result>(
+        _ message: RequestHeader,
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<ResponseHeader>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.ClientRequest<RequestHeader>(
+            message: message,
+            metadata: metadata
+        )
+        return try await self.switchProfile(
+            request: request,
+            options: options,
+            onResponse: handleResponse
+        )
+    }
+
+    /// Call the "CurrentProfile" method.
+    ///
+    /// - Parameters:
+    ///   - message: request message to send.
+    ///   - metadata: Additional metadata to send, defaults to empty.
+    ///   - options: Options to apply to this RPC, defaults to `.defaults`.
+    ///   - handleResponse: A closure which handles the response, the result of which is
+    ///       returned to the caller. Returning from the closure will cancel the RPC if it
+    ///       hasn't already finished.
+    /// - Returns: The result of `handleResponse`.
+    internal func currentProfile<Result>(
+        _ message: SwiftProtobuf.Google_Protobuf_Empty,
+        metadata: GRPCCore.Metadata = [:],
+        options: GRPCCore.CallOptions = .defaults,
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<CurrentProfileResponse>) async throws -> Result = { response in
+            try response.message
+        }
+    ) async throws -> Result where Result: Sendable {
+        let request = GRPCCore.ClientRequest<SwiftProtobuf.Google_Protobuf_Empty>(
+            message: message,
+            metadata: metadata
+        )
+        return try await self.currentProfile(
             request: request,
             options: options,
             onResponse: handleResponse

--- a/ee/psso/Bridge/Generated/agent_ctrl.pb.swift
+++ b/ee/psso/Bridge/Generated/agent_ctrl.pb.swift
@@ -79,9 +79,34 @@ nonisolated struct Profile: Sendable {
 
   var name: String = String()
 
+  var username: String = String()
+
+  var authentikURL: String = String()
+
+  var lastRenewed: SwiftProtobuf.Google_Protobuf_Timestamp {
+    get {_lastRenewed ?? SwiftProtobuf.Google_Protobuf_Timestamp()}
+    set {_lastRenewed = newValue}
+  }
+  /// Returns true if `lastRenewed` has been explicitly set.
+  var hasLastRenewed: Bool {self._lastRenewed != nil}
+  /// Clears the value of `lastRenewed`. Subsequent reads from it will return its default value.
+  mutating func clearLastRenewed() {self._lastRenewed = nil}
+
+  var nextRenew: SwiftProtobuf.Google_Protobuf_Timestamp {
+    get {_nextRenew ?? SwiftProtobuf.Google_Protobuf_Timestamp()}
+    set {_nextRenew = newValue}
+  }
+  /// Returns true if `nextRenew` has been explicitly set.
+  var hasNextRenew: Bool {self._nextRenew != nil}
+  /// Clears the value of `nextRenew`. Subsequent reads from it will return its default value.
+  mutating func clearNextRenew() {self._nextRenew = nil}
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
+
+  fileprivate var _lastRenewed: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
+  fileprivate var _nextRenew: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
 nonisolated struct ListProfilesResponse: Sendable {
@@ -99,6 +124,29 @@ nonisolated struct ListProfilesResponse: Sendable {
   mutating func clearHeader() {self._header = nil}
 
   var profiles: [Profile] = []
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+
+  fileprivate var _header: ResponseHeader? = nil
+}
+
+nonisolated struct CurrentProfileResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var header: ResponseHeader {
+    get {_header ?? ResponseHeader()}
+    set {_header = newValue}
+  }
+  /// Returns true if `header` has been explicitly set.
+  var hasHeader: Bool {self._header != nil}
+  /// Clears the value of `header`. Subsequent reads from it will return its default value.
+  mutating func clearHeader() {self._header = nil}
+
+  var profile: String = String()
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -206,7 +254,7 @@ nonisolated extension SetupResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
 
 nonisolated extension Profile: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Profile"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}username\0\u{3}authentik_url\0\u{3}last_renewed\0\u{3}next_renew\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -215,20 +263,44 @@ nonisolated extension Profile: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.name) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.username) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.authentikURL) }()
+      case 4: try { try decoder.decodeSingularMessageField(value: &self._lastRenewed) }()
+      case 5: try { try decoder.decodeSingularMessageField(value: &self._nextRenew) }()
       default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.name.isEmpty {
       try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
     }
+    if !self.username.isEmpty {
+      try visitor.visitSingularStringField(value: self.username, fieldNumber: 2)
+    }
+    if !self.authentikURL.isEmpty {
+      try visitor.visitSingularStringField(value: self.authentikURL, fieldNumber: 3)
+    }
+    try { if let v = self._lastRenewed {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    } }()
+    try { if let v = self._nextRenew {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Profile, rhs: Profile) -> Bool {
     if lhs.name != rhs.name {return false}
+    if lhs.username != rhs.username {return false}
+    if lhs.authentikURL != rhs.authentikURL {return false}
+    if lhs._lastRenewed != rhs._lastRenewed {return false}
+    if lhs._nextRenew != rhs._nextRenew {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -268,6 +340,45 @@ nonisolated extension ListProfilesResponse: SwiftProtobuf.Message, SwiftProtobuf
   static func ==(lhs: ListProfilesResponse, rhs: ListProfilesResponse) -> Bool {
     if lhs._header != rhs._header {return false}
     if lhs.profiles != rhs.profiles {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension CurrentProfileResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".CurrentProfileResponse"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}header\0\u{1}profile\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._header) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.profile) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._header {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if !self.profile.isEmpty {
+      try visitor.visitSingularStringField(value: self.profile, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: CurrentProfileResponse, rhs: CurrentProfileResponse) -> Bool {
+    if lhs._header != rhs._header {return false}
+    if lhs.profile != rhs.profile {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/ee/psso/authentikPlatform.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ee/psso/authentikPlatform.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
-        "version" : "1.3.1"
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     },
     {

--- a/pkg/pb/agent_ctrl.pb.go
+++ b/pkg/pb/agent_ctrl.pb.go
@@ -10,6 +10,7 @@ import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -153,6 +154,10 @@ func (x *SetupResponse) GetHeader() *ResponseHeader {
 type Profile struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Username      string                 `protobuf:"bytes,2,opt,name=username,proto3" json:"username,omitempty"`
+	AuthentikUrl  string                 `protobuf:"bytes,3,opt,name=authentik_url,json=authentikUrl,proto3" json:"authentik_url,omitempty"`
+	LastRenewed   *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=last_renewed,json=lastRenewed,proto3" json:"last_renewed,omitempty"`
+	NextRenew     *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=next_renew,json=nextRenew,proto3" json:"next_renew,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -192,6 +197,34 @@ func (x *Profile) GetName() string {
 		return x.Name
 	}
 	return ""
+}
+
+func (x *Profile) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *Profile) GetAuthentikUrl() string {
+	if x != nil {
+		return x.AuthentikUrl
+	}
+	return ""
+}
+
+func (x *Profile) GetLastRenewed() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastRenewed
+	}
+	return nil
+}
+
+func (x *Profile) GetNextRenew() *timestamppb.Timestamp {
+	if x != nil {
+		return x.NextRenew
+	}
+	return nil
 }
 
 type ListProfilesResponse struct {
@@ -246,12 +279,64 @@ func (x *ListProfilesResponse) GetProfiles() []*Profile {
 	return nil
 }
 
+type CurrentProfileResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Header        *ResponseHeader        `protobuf:"bytes,1,opt,name=header,proto3" json:"header,omitempty"`
+	Profile       string                 `protobuf:"bytes,2,opt,name=profile,proto3" json:"profile,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CurrentProfileResponse) Reset() {
+	*x = CurrentProfileResponse{}
+	mi := &file_agent_ctrl_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CurrentProfileResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CurrentProfileResponse) ProtoMessage() {}
+
+func (x *CurrentProfileResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agent_ctrl_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CurrentProfileResponse.ProtoReflect.Descriptor instead.
+func (*CurrentProfileResponse) Descriptor() ([]byte, []int) {
+	return file_agent_ctrl_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *CurrentProfileResponse) GetHeader() *ResponseHeader {
+	if x != nil {
+		return x.Header
+	}
+	return nil
+}
+
+func (x *CurrentProfileResponse) GetProfile() string {
+	if x != nil {
+		return x.Profile
+	}
+	return ""
+}
+
 var File_agent_ctrl_proto protoreflect.FileDescriptor
 
 const file_agent_ctrl_proto_rawDesc = "" +
 	"\n" +
 	"\x10agent_ctrl.proto\x12\n" +
-	"agent_ctrl\x1a\vagent.proto\x1a\x1bgoogle/protobuf/empty.proto\"\xe1\x01\n" +
+	"agent_ctrl\x1a\vagent.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xe1\x01\n" +
 	"\fSetupRequest\x12,\n" +
 	"\x06header\x18\x01 \x01(\v2\x14.agent.RequestHeaderR\x06header\x12#\n" +
 	"\rauthentik_url\x18\x02 \x01(\tR\fauthentikUrl\x12\x19\n" +
@@ -260,15 +345,25 @@ const file_agent_ctrl_proto_rawDesc = "" +
 	"\faccess_token\x18\x05 \x01(\tR\vaccessToken\x12#\n" +
 	"\rrefresh_token\x18\x06 \x01(\tR\frefreshToken\">\n" +
 	"\rSetupResponse\x12-\n" +
-	"\x06header\x18\x01 \x01(\v2\x15.agent.ResponseHeaderR\x06header\"\x1d\n" +
+	"\x06header\x18\x01 \x01(\v2\x15.agent.ResponseHeaderR\x06header\"\xd8\x01\n" +
 	"\aProfile\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\"v\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
+	"\busername\x18\x02 \x01(\tR\busername\x12#\n" +
+	"\rauthentik_url\x18\x03 \x01(\tR\fauthentikUrl\x12=\n" +
+	"\flast_renewed\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\vlastRenewed\x129\n" +
+	"\n" +
+	"next_renew\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tnextRenew\"v\n" +
 	"\x14ListProfilesResponse\x12-\n" +
 	"\x06header\x18\x01 \x01(\v2\x15.agent.ResponseHeaderR\x06header\x12/\n" +
-	"\bprofiles\x18\x02 \x03(\v2\x13.agent_ctrl.ProfileR\bprofiles2\x93\x01\n" +
+	"\bprofiles\x18\x02 \x03(\v2\x13.agent_ctrl.ProfileR\bprofiles\"a\n" +
+	"\x16CurrentProfileResponse\x12-\n" +
+	"\x06header\x18\x01 \x01(\v2\x15.agent.ResponseHeaderR\x06header\x12\x18\n" +
+	"\aprofile\x18\x02 \x01(\tR\aprofile2\x9f\x02\n" +
 	"\tAgentCtrl\x12H\n" +
 	"\fListProfiles\x12\x16.google.protobuf.Empty\x1a .agent_ctrl.ListProfilesResponse\x12<\n" +
-	"\x05Setup\x12\x18.agent_ctrl.SetupRequest\x1a\x19.agent_ctrl.SetupResponseB\vZ\x06pkg/pb\xba\x02\x00b\x06proto3"
+	"\x05Setup\x12\x18.agent_ctrl.SetupRequest\x1a\x19.agent_ctrl.SetupResponse\x12<\n" +
+	"\rSwitchProfile\x12\x14.agent.RequestHeader\x1a\x15.agent.ResponseHeader\x12L\n" +
+	"\x0eCurrentProfile\x12\x16.google.protobuf.Empty\x1a\".agent_ctrl.CurrentProfileResponseB\vZ\x06pkg/pb\xba\x02\x00b\x06proto3"
 
 var (
 	file_agent_ctrl_proto_rawDescOnce sync.Once
@@ -282,30 +377,39 @@ func file_agent_ctrl_proto_rawDescGZIP() []byte {
 	return file_agent_ctrl_proto_rawDescData
 }
 
-var file_agent_ctrl_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_agent_ctrl_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_agent_ctrl_proto_goTypes = []any{
-	(*SetupRequest)(nil),         // 0: agent_ctrl.SetupRequest
-	(*SetupResponse)(nil),        // 1: agent_ctrl.SetupResponse
-	(*Profile)(nil),              // 2: agent_ctrl.Profile
-	(*ListProfilesResponse)(nil), // 3: agent_ctrl.ListProfilesResponse
-	(*RequestHeader)(nil),        // 4: agent.RequestHeader
-	(*ResponseHeader)(nil),       // 5: agent.ResponseHeader
-	(*emptypb.Empty)(nil),        // 6: google.protobuf.Empty
+	(*SetupRequest)(nil),           // 0: agent_ctrl.SetupRequest
+	(*SetupResponse)(nil),          // 1: agent_ctrl.SetupResponse
+	(*Profile)(nil),                // 2: agent_ctrl.Profile
+	(*ListProfilesResponse)(nil),   // 3: agent_ctrl.ListProfilesResponse
+	(*CurrentProfileResponse)(nil), // 4: agent_ctrl.CurrentProfileResponse
+	(*RequestHeader)(nil),          // 5: agent.RequestHeader
+	(*ResponseHeader)(nil),         // 6: agent.ResponseHeader
+	(*timestamppb.Timestamp)(nil),  // 7: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),          // 8: google.protobuf.Empty
 }
 var file_agent_ctrl_proto_depIdxs = []int32{
-	4, // 0: agent_ctrl.SetupRequest.header:type_name -> agent.RequestHeader
-	5, // 1: agent_ctrl.SetupResponse.header:type_name -> agent.ResponseHeader
-	5, // 2: agent_ctrl.ListProfilesResponse.header:type_name -> agent.ResponseHeader
-	2, // 3: agent_ctrl.ListProfilesResponse.profiles:type_name -> agent_ctrl.Profile
-	6, // 4: agent_ctrl.AgentCtrl.ListProfiles:input_type -> google.protobuf.Empty
-	0, // 5: agent_ctrl.AgentCtrl.Setup:input_type -> agent_ctrl.SetupRequest
-	3, // 6: agent_ctrl.AgentCtrl.ListProfiles:output_type -> agent_ctrl.ListProfilesResponse
-	1, // 7: agent_ctrl.AgentCtrl.Setup:output_type -> agent_ctrl.SetupResponse
-	6, // [6:8] is the sub-list for method output_type
-	4, // [4:6] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	5,  // 0: agent_ctrl.SetupRequest.header:type_name -> agent.RequestHeader
+	6,  // 1: agent_ctrl.SetupResponse.header:type_name -> agent.ResponseHeader
+	7,  // 2: agent_ctrl.Profile.last_renewed:type_name -> google.protobuf.Timestamp
+	7,  // 3: agent_ctrl.Profile.next_renew:type_name -> google.protobuf.Timestamp
+	6,  // 4: agent_ctrl.ListProfilesResponse.header:type_name -> agent.ResponseHeader
+	2,  // 5: agent_ctrl.ListProfilesResponse.profiles:type_name -> agent_ctrl.Profile
+	6,  // 6: agent_ctrl.CurrentProfileResponse.header:type_name -> agent.ResponseHeader
+	8,  // 7: agent_ctrl.AgentCtrl.ListProfiles:input_type -> google.protobuf.Empty
+	0,  // 8: agent_ctrl.AgentCtrl.Setup:input_type -> agent_ctrl.SetupRequest
+	5,  // 9: agent_ctrl.AgentCtrl.SwitchProfile:input_type -> agent.RequestHeader
+	8,  // 10: agent_ctrl.AgentCtrl.CurrentProfile:input_type -> google.protobuf.Empty
+	3,  // 11: agent_ctrl.AgentCtrl.ListProfiles:output_type -> agent_ctrl.ListProfilesResponse
+	1,  // 12: agent_ctrl.AgentCtrl.Setup:output_type -> agent_ctrl.SetupResponse
+	6,  // 13: agent_ctrl.AgentCtrl.SwitchProfile:output_type -> agent.ResponseHeader
+	4,  // 14: agent_ctrl.AgentCtrl.CurrentProfile:output_type -> agent_ctrl.CurrentProfileResponse
+	11, // [11:15] is the sub-list for method output_type
+	7,  // [7:11] is the sub-list for method input_type
+	7,  // [7:7] is the sub-list for extension type_name
+	7,  // [7:7] is the sub-list for extension extendee
+	0,  // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_agent_ctrl_proto_init() }
@@ -320,7 +424,7 @@ func file_agent_ctrl_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agent_ctrl_proto_rawDesc), len(file_agent_ctrl_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/pb/agent_ctrl_grpc.pb.go
+++ b/pkg/pb/agent_ctrl_grpc.pb.go
@@ -20,8 +20,10 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	AgentCtrl_ListProfiles_FullMethodName = "/agent_ctrl.AgentCtrl/ListProfiles"
-	AgentCtrl_Setup_FullMethodName        = "/agent_ctrl.AgentCtrl/Setup"
+	AgentCtrl_ListProfiles_FullMethodName   = "/agent_ctrl.AgentCtrl/ListProfiles"
+	AgentCtrl_Setup_FullMethodName          = "/agent_ctrl.AgentCtrl/Setup"
+	AgentCtrl_SwitchProfile_FullMethodName  = "/agent_ctrl.AgentCtrl/SwitchProfile"
+	AgentCtrl_CurrentProfile_FullMethodName = "/agent_ctrl.AgentCtrl/CurrentProfile"
 )
 
 // AgentCtrlClient is the client API for AgentCtrl service.
@@ -30,6 +32,8 @@ const (
 type AgentCtrlClient interface {
 	ListProfiles(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*ListProfilesResponse, error)
 	Setup(ctx context.Context, in *SetupRequest, opts ...grpc.CallOption) (*SetupResponse, error)
+	SwitchProfile(ctx context.Context, in *RequestHeader, opts ...grpc.CallOption) (*ResponseHeader, error)
+	CurrentProfile(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*CurrentProfileResponse, error)
 }
 
 type agentCtrlClient struct {
@@ -60,12 +64,34 @@ func (c *agentCtrlClient) Setup(ctx context.Context, in *SetupRequest, opts ...g
 	return out, nil
 }
 
+func (c *agentCtrlClient) SwitchProfile(ctx context.Context, in *RequestHeader, opts ...grpc.CallOption) (*ResponseHeader, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ResponseHeader)
+	err := c.cc.Invoke(ctx, AgentCtrl_SwitchProfile_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *agentCtrlClient) CurrentProfile(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*CurrentProfileResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CurrentProfileResponse)
+	err := c.cc.Invoke(ctx, AgentCtrl_CurrentProfile_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // AgentCtrlServer is the server API for AgentCtrl service.
 // All implementations must embed UnimplementedAgentCtrlServer
 // for forward compatibility.
 type AgentCtrlServer interface {
 	ListProfiles(context.Context, *emptypb.Empty) (*ListProfilesResponse, error)
 	Setup(context.Context, *SetupRequest) (*SetupResponse, error)
+	SwitchProfile(context.Context, *RequestHeader) (*ResponseHeader, error)
+	CurrentProfile(context.Context, *emptypb.Empty) (*CurrentProfileResponse, error)
 	mustEmbedUnimplementedAgentCtrlServer()
 }
 
@@ -81,6 +107,12 @@ func (UnimplementedAgentCtrlServer) ListProfiles(context.Context, *emptypb.Empty
 }
 func (UnimplementedAgentCtrlServer) Setup(context.Context, *SetupRequest) (*SetupResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Setup not implemented")
+}
+func (UnimplementedAgentCtrlServer) SwitchProfile(context.Context, *RequestHeader) (*ResponseHeader, error) {
+	return nil, status.Error(codes.Unimplemented, "method SwitchProfile not implemented")
+}
+func (UnimplementedAgentCtrlServer) CurrentProfile(context.Context, *emptypb.Empty) (*CurrentProfileResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CurrentProfile not implemented")
 }
 func (UnimplementedAgentCtrlServer) mustEmbedUnimplementedAgentCtrlServer() {}
 func (UnimplementedAgentCtrlServer) testEmbeddedByValue()                   {}
@@ -139,6 +171,42 @@ func _AgentCtrl_Setup_Handler(srv interface{}, ctx context.Context, dec func(int
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AgentCtrl_SwitchProfile_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RequestHeader)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AgentCtrlServer).SwitchProfile(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AgentCtrl_SwitchProfile_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AgentCtrlServer).SwitchProfile(ctx, req.(*RequestHeader))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AgentCtrl_CurrentProfile_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(emptypb.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AgentCtrlServer).CurrentProfile(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AgentCtrl_CurrentProfile_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AgentCtrlServer).CurrentProfile(ctx, req.(*emptypb.Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // AgentCtrl_ServiceDesc is the grpc.ServiceDesc for AgentCtrl service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -153,6 +221,14 @@ var AgentCtrl_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Setup",
 			Handler:    _AgentCtrl_Setup_Handler,
+		},
+		{
+			MethodName: "SwitchProfile",
+			Handler:    _AgentCtrl_SwitchProfile_Handler,
+		},
+		{
+			MethodName: "CurrentProfile",
+			Handler:    _AgentCtrl_CurrentProfile_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   ak-agent-desktop:
     dependencies:
+      '@goauthentik/api':
+        specifier: ^2026.5.3
+        version: 2026.5.3
       '@goauthentik/brand-assets':
         specifier: ^2.0.0
         version: 2.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,13 +22,16 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.4
+      '@tauri-apps/plugin-os':
+        specifier: ~2.3.2
+        version: 2.3.2
       lit:
         specifier: ^3.3.3
         version: 3.3.3
     devDependencies:
       '@goauthentik/eslint-config':
         specifier: ^2.0.0
-        version: 2.0.0(typescript-eslint@8.61.1(eslint@8.57.1)(typescript@6.0.3))(typescript@6.0.3)
+        version: 2.0.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4)(typescript@6.0.3))(typescript-eslint@8.61.1(eslint@9.39.4)(typescript@6.0.3))(typescript@6.0.3)
       '@goauthentik/prettier-config':
         specifier: ^3.5.0
         version: 3.5.0(prettier-plugin-packagejson@3.0.2(prettier@3.8.4))(prettier@3.8.4)
@@ -804,6 +807,9 @@ packages:
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
+
+  '@tauri-apps/plugin-os@2.3.2':
+    resolution: {integrity: sha512-n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A==}
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -2600,23 +2606,6 @@ snapshots:
       - jiti
       - supports-color
 
-  '@goauthentik/eslint-config@2.0.0(typescript-eslint@8.61.1(eslint@8.57.1)(typescript@6.0.3))(typescript@6.0.3)':
-    dependencies:
-      eslint: 9.39.4
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)
-      eslint-plugin-lit: 2.3.1(eslint@9.39.4)
-      eslint-plugin-react: 7.37.5(eslint@9.39.4)
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4)
-      eslint-plugin-wc: 3.1.0(eslint@9.39.4)
-      typescript: 6.0.3
-      typescript-eslint: 8.61.1(eslint@8.57.1)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - jiti
-      - supports-color
-
   '@goauthentik/prettier-config@3.5.0(prettier-plugin-packagejson@3.0.2(prettier@3.8.4))(prettier@3.8.4)':
     dependencies:
       format-imports: 4.0.8
@@ -2999,6 +2988,10 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.1
 
+  '@tauri-apps/plugin-os@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -3027,22 +3020,6 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
-  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.61.1(eslint@8.57.1)(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/type-utils': 8.61.1(eslint@8.57.1)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@8.57.1)(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.61.1
-      eslint: 8.57.1
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -3055,18 +3032,6 @@ snapshots:
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.61.1(eslint@8.57.1)(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.61.1
-      debug: 4.4.3
-      eslint: 8.57.1
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -3101,18 +3066,6 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.61.1(eslint@8.57.1)(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@8.57.1)(typescript@6.0.3)
-      debug: 4.4.3
-      eslint: 8.57.1
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/type-utils@8.61.1(eslint@9.39.4)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.61.1
@@ -3138,17 +3091,6 @@ snapshots:
       semver: 7.8.4
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.61.1(eslint@8.57.1)(typescript@6.0.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
-      eslint: 8.57.1
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -4775,17 +4717,6 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
-
-  typescript-eslint@8.61.1(eslint@8.57.1)(typescript@6.0.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.61.1(eslint@8.57.1)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@8.57.1)(typescript@6.0.3)
-      eslint: 8.57.1
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
 
   typescript-eslint@8.61.1(eslint@9.39.4)(typescript@6.0.3):
     dependencies:

--- a/protobuf/agent_ctrl.proto
+++ b/protobuf/agent_ctrl.proto
@@ -11,6 +11,8 @@ import "google/protobuf/timestamp.proto";
 service AgentCtrl {
   rpc ListProfiles(google.protobuf.Empty) returns (ListProfilesResponse);
   rpc Setup(SetupRequest) returns (SetupResponse);
+  rpc SwitchProfile(agent.RequestHeader) returns (agent.ResponseHeader);
+  rpc CurrentProfile(google.protobuf.Empty) returns (CurrentProfileResponse);
 }
 
 message SetupRequest {
@@ -37,4 +39,9 @@ message Profile {
 message ListProfilesResponse {
   agent.ResponseHeader header = 1;
   repeated Profile profiles = 2;
+}
+
+message CurrentProfileResponse {
+  agent.ResponseHeader header = 1;
+  string profile = 2;
 }

--- a/vpkg/macos/authentik Agent.app/Contents/Info.plist
+++ b/vpkg/macos/authentik Agent.app/Contents/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDisplayName</key>
 	<string>authentik Agent</string>
+	<key>CFBundleName</key>
+	<string>authentik Agent</string>
 	<key>CFBundleExecutable</key>
 	<string>ak-agent-desktop</string>
 	<key>CFBundleIconFile</key>


### PR DESCRIPTION
currently to use different profiles you'd always need to supply the `--profile` or `-p` flag which can be tedious, and some parts like the SSH agent didn't support different profiles at all.

With this you can still specify a profile like that, but you can also use `ak s <profile_name>` to switch to a different default profile which will be used for the SSH agent and requests where no profile is specified.

Also includes a bunch of UI improvements