### PR TITLE
ak-pam: configure dependencies to work with pam-libs and pam

### DIFF
--- a/ak-platform-e2e/tests/pkg.rs
+++ b/ak-platform-e2e/tests/pkg.rs
@@ -44,6 +44,7 @@ async fn test_packaging_rpm() {
     for (image, tag) in &[
         ("docker.io/redhat/ubi10", "latest"),
         ("docker.io/library/almalinux", "10"),
+        ("docker.io/library/amazonlinux", "2023"),
     ] {
         let container = pkg_container(image, tag, &bin_dir).await;
 

--- a/vpkg/linux/pam/nfpm.yaml
+++ b/vpkg/linux/pam/nfpm.yaml
@@ -45,7 +45,7 @@ overrides:
     depends:
       - "authentik-sysd"
       - "glibc"
-      - "pam-libs"
+      - "(pam-libs or pam)"
       # Dependency on NSS due to authselect configuring both
       - "libnss-authentik"
     scripts:


### PR DESCRIPTION
Some RPM distributions provide the pam libraries embedded in pam itself rather than a separate pam-libs package.

Closes #1231