### PR TITLE
ak-platform: add void logger as fallback

### DIFF
--- a/ak-platform/src/log/mod.rs
+++ b/ak-platform/src/log/mod.rs
@@ -19,6 +19,7 @@ pub mod windows;
 #[cfg(unix)]
 pub mod unix;
 
+pub mod void;
 pub struct LogBuilder {
     name: PlatformString,
     filter: Vec<(String, LevelFilter)>,
@@ -110,7 +111,7 @@ impl LogBuilder {
         } else {
             match self.get_platform_logger() {
                 Ok(l) => l,
-                Err(_) => self.get_stdout_logger(),
+                Err(_) => void::VoidLogger::new(),
             }
         };
         (Box::new(FilteredLog::new(inner, filter)), max_level)

--- a/ak-platform/src/log/mod.rs
+++ b/ak-platform/src/log/mod.rs
@@ -104,14 +104,19 @@ impl LogBuilder {
             .iter()
             .map(|(_, level)| *level)
             .fold(self.default_level, std::cmp::max);
-        let inner: Box<dyn Log> = if (self.allow_platform && env_interactive())
-            || (self.force_stdout && self.allow_stdout)
+        let inner: Box<dyn Log> = if self.allow_stdout && (env_interactive() || self.force_stdout)
         {
             self.get_stdout_logger()
         } else {
             match self.get_platform_logger() {
                 Ok(l) => l,
-                Err(_) => void::VoidLogger::new(),
+                Err(_) => {
+                    if self.allow_stdout {
+                        self.get_stdout_logger()
+                    } else {
+                        void::VoidLogger::new()
+                    }
+                }
             }
         };
         (Box::new(FilteredLog::new(inner, filter)), max_level)

--- a/ak-platform/src/log/void.rs
+++ b/ak-platform/src/log/void.rs
@@ -1,0 +1,19 @@
+use log::Log;
+
+pub(crate) struct VoidLogger {}
+
+impl VoidLogger {
+    pub fn new() -> Box<Self> {
+        Self {}.into()
+    }
+}
+
+impl Log for VoidLogger {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        false
+    }
+
+    fn log(&self, _record: &log::Record) {}
+
+    fn flush(&self) {}
+}

--- a/common.mk
+++ b/common.mk
@@ -10,7 +10,7 @@ ifeq ($(CI),true)
 	ifeq ($(AK_IS_RELEASE),true)
 		VERSION_PKG = ${VERSION}
 	else
-		VERSION_PKG = ${VERSION}+ak-${shell git rev-parse HEAD | head -c 8}
+		VERSION_PKG = ${VERSION}+ak-${shell git rev-parse HEAD | head -c 8}-$(GITHUB_RUN_ID)
 	endif
 else
 	VERSION_PKG = ${VERSION}


### PR DESCRIPTION
should fix libnss/libpam spamming stdout with logs when they cant connect