### PR TITLE
ak-nss: fix not found warning

### DIFF
--- a/ak-nss/src/backend.rs
+++ b/ak-nss/src/backend.rs
@@ -1,25 +1,25 @@
 use ak_platform::generated::sys_directory::{
     GetRequest, Group as AKGroup, User, system_directory_client::SystemDirectoryClient,
 };
-use ak_platform::grpc::grpc_request;
+use ak_platform::grpc::{GrpcError, GrpcResult, grpc_request};
 use eyre::Result;
 
 pub trait DirectoryBridge {
-    fn list_users(&self) -> Result<Vec<User>>;
-    fn get_user(&self, req: GetRequest) -> Result<User>;
-    fn list_groups(&self) -> Result<Vec<AKGroup>>;
-    fn get_group(&self, req: GetRequest) -> Result<AKGroup>;
+    fn list_users(&self) -> GrpcResult<Vec<User>>;
+    fn get_user(&self, req: GetRequest) -> GrpcResult<User>;
+    fn list_groups(&self) -> GrpcResult<Vec<AKGroup>>;
+    fn get_group(&self, req: GetRequest) -> GrpcResult<AKGroup>;
 }
 
 pub struct GrpcDirectoryBridge;
 
 impl DirectoryBridge for GrpcDirectoryBridge {
-    fn list_users(&self) -> Result<Vec<User>> {
+    fn list_users(&self) -> GrpcResult<Vec<User>> {
         grpc_request(async |ch| Ok(SystemDirectoryClient::new(ch).list_users(()).await?))
             .map(|r| r.into_inner().users)
     }
 
-    fn get_user(&self, req: GetRequest) -> Result<User> {
+    fn get_user(&self, req: GetRequest) -> GrpcResult<User> {
         grpc_request(move |ch| {
             let req = req.clone();
             async move { Ok(SystemDirectoryClient::new(ch).get_user(req).await?) }
@@ -27,12 +27,12 @@ impl DirectoryBridge for GrpcDirectoryBridge {
         .map(|r| r.into_inner())
     }
 
-    fn list_groups(&self) -> Result<Vec<AKGroup>> {
+    fn list_groups(&self) -> GrpcResult<Vec<AKGroup>> {
         grpc_request(async |ch| Ok(SystemDirectoryClient::new(ch).list_groups(()).await?))
             .map(|r| r.into_inner().groups)
     }
 
-    fn get_group(&self, req: GetRequest) -> Result<AKGroup> {
+    fn get_group(&self, req: GetRequest) -> GrpcResult<AKGroup> {
         grpc_request(move |ch| {
             let req = req.clone();
             async move { Ok(SystemDirectoryClient::new(ch).get_group(req).await?) }

--- a/ak-nss/src/backend.rs
+++ b/ak-nss/src/backend.rs
@@ -1,8 +1,8 @@
 use ak_platform::generated::sys_directory::{
     GetRequest, Group as AKGroup, User, system_directory_client::SystemDirectoryClient,
 };
-use ak_platform::grpc::{GrpcError, GrpcResult, grpc_request};
-use eyre::Result;
+use ak_platform::grpc::{Code, GrpcError, GrpcResult, grpc_request};
+use libnss::interop::Response;
 
 pub trait DirectoryBridge {
     fn list_users(&self) -> GrpcResult<Vec<User>>;
@@ -38,5 +38,105 @@ impl DirectoryBridge for GrpcDirectoryBridge {
             async move { Ok(SystemDirectoryClient::new(ch).get_group(req).await?) }
         })
         .map(|r| r.into_inner())
+    }
+}
+
+pub trait ErrMap<T> {
+    fn to_response<C: ToString>(self, context: C) -> Response<T>;
+}
+
+impl<T> ErrMap<T> for GrpcResult<T> {
+    fn to_response<C: ToString>(self, context: C) -> Response<T> {
+        match self {
+            Ok(t) => Response::Success(t),
+            Err(e) => match e {
+                GrpcError::Status(s) => match s.code() {
+                    Code::NotFound => Response::NotFound,
+                    other => {
+                        tracing::warn!(
+                            "{}: {} ({})",
+                            context.to_string(),
+                            other,
+                            other.description()
+                        );
+                        Response::Unavail
+                    }
+                },
+                other => {
+                    tracing::warn!("{}: {}", context.to_string(), other);
+                    Response::Unavail
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ak_platform::grpc::Status;
+
+    /// The whole point of the mapping: sysd's `Status::not_found` must reach NSS
+    /// as NOTFOUND. It used to arrive as UNAVAIL, i.e. "this backend is broken".
+    #[test]
+    fn not_found_is_the_only_miss() {
+        let res: GrpcResult<u8> = Err(Status::not_found("user not found").into());
+        assert!(matches!(res.to_response("ctx"), Response::NotFound));
+    }
+
+    #[test]
+    fn every_other_code_is_unavail() {
+        for code in [
+            Code::Ok,
+            Code::Cancelled,
+            Code::Unknown,
+            Code::InvalidArgument,
+            Code::DeadlineExceeded,
+            Code::AlreadyExists,
+            Code::PermissionDenied,
+            Code::ResourceExhausted,
+            Code::FailedPrecondition,
+            Code::Aborted,
+            Code::OutOfRange,
+            Code::Unimplemented,
+            Code::Internal,
+            Code::Unavailable,
+            Code::DataLoss,
+            Code::Unauthenticated,
+        ] {
+            let res: GrpcResult<u8> = Err(Status::new(code, "x").into());
+            assert!(
+                matches!(res.to_response("ctx"), Response::Unavail),
+                "{code:?} must not be reported as a miss"
+            );
+        }
+    }
+
+    /// Failures that never reached sysd carry no gRPC code at all, and are
+    /// likewise not misses.
+    #[test]
+    fn non_status_errors_are_unavail() {
+        let res: GrpcResult<u8> = Err(GrpcError::Other(eyre::eyre!("no tokio runtime")));
+        assert!(matches!(res.to_response("ctx"), Response::Unavail));
+    }
+
+    #[test]
+    fn success_passes_the_value_through() {
+        let res: GrpcResult<u8> = Ok(7);
+        assert!(matches!(res.to_response("ctx"), Response::Success(7)));
+    }
+
+    /// TryAgain risks an unbounded glibc retry loop and Return would abort the
+    /// nsswitch chain, so neither may ever be produced. See `to_response`'s docs.
+    #[test]
+    fn never_try_again_or_return() {
+        for err in [
+            GrpcError::Status(Status::not_found("x")),
+            GrpcError::Status(Status::internal("x")),
+            GrpcError::Other(eyre::eyre!("x")),
+        ] {
+            let res: Response<u8> = Err(err).to_response("ctx");
+            assert!(!matches!(res, Response::TryAgain | Response::Return));
+        }
     }
 }

--- a/ak-nss/src/group.rs
+++ b/ak-nss/src/group.rs
@@ -1,4 +1,5 @@
 use ak_platform::generated::sys_directory::GetRequest;
+use ak_platform::grpc::GrpcError;
 use libc::gid_t;
 use libnss::group::{Group, GroupHooks};
 use libnss::interop::Response;
@@ -27,6 +28,7 @@ impl GroupHooks for AuthentikNSS {
 fn get_all_entries_with(bridge: &impl DirectoryBridge) -> Response<Vec<Group>> {
     match bridge.list_groups() {
         Ok(groups) => Response::Success(groups.into_iter().map(ak_group_to_group_entry).collect()),
+        Err(GrpcError::NotFound) => Response::NotFound,
         Err(e) => {
             tracing::warn!("Failed to get groups: {e:?}");
             Response::Unavail
@@ -40,6 +42,7 @@ fn get_entry_by_gid_with(bridge: &impl DirectoryBridge, gid: gid_t) -> Response<
         id: Some(gid),
     }) {
         Ok(group) => Response::Success(ak_group_to_group_entry(group)),
+        Err(GrpcError::NotFound) => Response::NotFound,
         Err(e) => {
             tracing::warn!("error when getting group by ID '{gid}': {e:?}");
             Response::Unavail
@@ -53,6 +56,7 @@ fn get_entry_by_name_with(bridge: &impl DirectoryBridge, name: String) -> Respon
         id: None,
     }) {
         Ok(group) => Response::Success(ak_group_to_group_entry(group)),
+        Err(GrpcError::NotFound) => Response::NotFound,
         Err(e) => {
             tracing::warn!("error when getting group by name '{name}': {e:?}");
             Response::Unavail

--- a/ak-nss/src/group.rs
+++ b/ak-nss/src/group.rs
@@ -1,10 +1,10 @@
 use ak_platform::generated::sys_directory::GetRequest;
-use ak_platform::grpc::GrpcError;
 use libc::gid_t;
 use libnss::group::{Group, GroupHooks};
 use libnss::interop::Response;
 
 use crate::AuthentikNSS;
+use crate::backend::ErrMap;
 use crate::backend::{DirectoryBridge, GrpcDirectoryBridge};
 use crate::mapping::ak_group_to_group_entry;
 
@@ -26,65 +26,53 @@ impl GroupHooks for AuthentikNSS {
 }
 
 fn get_all_entries_with(bridge: &impl DirectoryBridge) -> Response<Vec<Group>> {
-    match bridge.list_groups() {
-        Ok(groups) => Response::Success(groups.into_iter().map(ak_group_to_group_entry).collect()),
-        Err(GrpcError::NotFound) => Response::NotFound,
-        Err(e) => {
-            tracing::warn!("Failed to get groups: {e:?}");
-            Response::Unavail
-        }
-    }
+    bridge
+        .list_groups()
+        .map(|groups| groups.into_iter().map(ak_group_to_group_entry).collect())
+        .to_response("failed to list groups")
 }
 
 fn get_entry_by_gid_with(bridge: &impl DirectoryBridge, gid: gid_t) -> Response<Group> {
-    match bridge.get_group(GetRequest {
-        name: None,
-        id: Some(gid),
-    }) {
-        Ok(group) => Response::Success(ak_group_to_group_entry(group)),
-        Err(GrpcError::NotFound) => Response::NotFound,
-        Err(e) => {
-            tracing::warn!("error when getting group by ID '{gid}': {e:?}");
-            Response::Unavail
-        }
-    }
+    bridge
+        .get_group(GetRequest {
+            name: None,
+            id: Some(gid),
+        })
+        .map(ak_group_to_group_entry)
+        .to_response(format!("failed to get group by ID '{gid}'"))
 }
 
 fn get_entry_by_name_with(bridge: &impl DirectoryBridge, name: String) -> Response<Group> {
-    match bridge.get_group(GetRequest {
-        name: Some(name.clone()),
-        id: None,
-    }) {
-        Ok(group) => Response::Success(ak_group_to_group_entry(group)),
-        Err(GrpcError::NotFound) => Response::NotFound,
-        Err(e) => {
-            tracing::warn!("error when getting group by name '{name}': {e:?}");
-            Response::Unavail
-        }
-    }
+    bridge
+        .get_group(GetRequest {
+            name: Some(name.clone()),
+            id: None,
+        })
+        .map(ak_group_to_group_entry)
+        .to_response(format!("failed to get group by name '{name}'"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use ak_platform::generated::sys_directory::{Group as AKGroup, User};
-    use eyre::Result;
+    use ak_platform::grpc::{GrpcResult, Status};
 
     struct MockBridge {
         groups: Vec<AKGroup>,
     }
 
     impl DirectoryBridge for MockBridge {
-        fn list_users(&self) -> Result<Vec<User>> {
+        fn list_users(&self) -> GrpcResult<Vec<User>> {
             unreachable!()
         }
-        fn get_user(&self, _req: GetRequest) -> Result<User> {
+        fn get_user(&self, _req: GetRequest) -> GrpcResult<User> {
             unreachable!()
         }
-        fn list_groups(&self) -> Result<Vec<AKGroup>> {
+        fn list_groups(&self) -> GrpcResult<Vec<AKGroup>> {
             Ok(self.groups.clone())
         }
-        fn get_group(&self, req: GetRequest) -> Result<AKGroup> {
+        fn get_group(&self, req: GetRequest) -> GrpcResult<AKGroup> {
             self.groups
                 .iter()
                 .find(|g| {
@@ -92,23 +80,40 @@ mod tests {
                         || req.name.as_deref().map_or(false, |n| n == g.name)
                 })
                 .cloned()
-                .ok_or_else(|| eyre::eyre!("not found"))
+                .ok_or_else(|| Status::not_found("no such entry").into())
         }
     }
 
-    struct ErrorBridge;
-    impl DirectoryBridge for ErrorBridge {
-        fn list_users(&self) -> Result<Vec<User>> {
+    struct UnavailBridge;
+    impl DirectoryBridge for UnavailBridge {
+        fn list_users(&self) -> GrpcResult<Vec<User>> {
             unreachable!()
         }
-        fn get_user(&self, _: GetRequest) -> Result<User> {
+        fn get_user(&self, _: GetRequest) -> GrpcResult<User> {
             unreachable!()
         }
-        fn list_groups(&self) -> Result<Vec<AKGroup>> {
-            Err(eyre::eyre!("unavailable"))
+        fn list_groups(&self) -> GrpcResult<Vec<AKGroup>> {
+            Err(Status::unavailable("connect failed").into())
         }
-        fn get_group(&self, _: GetRequest) -> Result<AKGroup> {
-            Err(eyre::eyre!("unavailable"))
+        fn get_group(&self, _: GetRequest) -> GrpcResult<AKGroup> {
+            Err(Status::unavailable("connect failed").into())
+        }
+    }
+
+    /// sysd answered, and there is no such entry.
+    struct NotFoundBridge;
+    impl DirectoryBridge for NotFoundBridge {
+        fn list_users(&self) -> GrpcResult<Vec<User>> {
+            Err(Status::not_found("no such entry").into())
+        }
+        fn get_user(&self, _: GetRequest) -> GrpcResult<User> {
+            Err(Status::not_found("no such entry").into())
+        }
+        fn list_groups(&self) -> GrpcResult<Vec<AKGroup>> {
+            Err(Status::not_found("no such entry").into())
+        }
+        fn get_group(&self, _: GetRequest) -> GrpcResult<AKGroup> {
+            Err(Status::not_found("no such entry").into())
         }
     }
 
@@ -140,7 +145,7 @@ mod tests {
     #[test]
     fn get_all_entries_unavail_on_error() {
         assert!(matches!(
-            get_all_entries_with(&ErrorBridge),
+            get_all_entries_with(&UnavailBridge),
             Response::Unavail
         ));
     }
@@ -159,7 +164,7 @@ mod tests {
     #[test]
     fn get_entry_by_gid_unavail_on_error() {
         assert!(matches!(
-            get_entry_by_gid_with(&ErrorBridge, 200),
+            get_entry_by_gid_with(&UnavailBridge, 200),
             Response::Unavail
         ));
     }
@@ -178,8 +183,40 @@ mod tests {
     #[test]
     fn get_entry_by_name_unavail_on_error() {
         assert!(matches!(
-            get_entry_by_name_with(&ErrorBridge, "admins".to_owned()),
+            get_entry_by_name_with(&UnavailBridge, "admins".to_owned()),
             Response::Unavail
+        ));
+    }
+
+    /// A gid that simply isn't in the directory is NOTFOUND, not UNAVAIL.
+    #[test]
+    fn get_entry_by_gid_notfound_when_missing() {
+        let bridge = MockBridge {
+            groups: vec![admins()],
+        };
+        assert!(matches!(
+            get_entry_by_gid_with(&bridge, 4242),
+            Response::NotFound
+        ));
+        assert!(matches!(
+            get_entry_by_gid_with(&NotFoundBridge, 4242),
+            Response::NotFound
+        ));
+    }
+
+    /// A group name that simply isn't in the directory is NOTFOUND, not UNAVAIL.
+    #[test]
+    fn get_entry_by_name_notfound_when_missing() {
+        let bridge = MockBridge {
+            groups: vec![admins()],
+        };
+        assert!(matches!(
+            get_entry_by_name_with(&bridge, "nosuchgroup".to_owned()),
+            Response::NotFound
+        ));
+        assert!(matches!(
+            get_entry_by_name_with(&NotFoundBridge, "nosuchgroup".to_owned()),
+            Response::NotFound
         ));
     }
 }

--- a/ak-nss/src/mapping.rs
+++ b/ak-nss/src/mapping.rs
@@ -3,30 +3,44 @@ use libnss::group::Group;
 use libnss::passwd::Passwd;
 use libnss::shadow::Shadow;
 
+/// libnss marshals these strings with `CString::new(..).expect(..)`
+/// (libnss 0.9.0 `interop.rs`), which panics inside an `extern "C"` NSS entry
+/// point — aborting whatever called us, i.e. sshd or login — if a field contains
+/// an interior NUL. Directory data is remote-controlled, so strip NULs before
+/// they get that far.
+fn nss_safe(s: String) -> String {
+    if s.contains('\0') {
+        tracing::warn!("stripping NUL byte(s) from directory field");
+        s.replace('\0', "")
+    } else {
+        s
+    }
+}
+
 pub fn user_to_passwd_entry(entry: User) -> Passwd {
     Passwd {
-        name: entry.name,
+        name: nss_safe(entry.name),
         passwd: "x".to_owned(),
         uid: entry.uid,
         gid: entry.gid,
-        gecos: entry.gecos,
-        dir: entry.homedir,
-        shell: entry.shell,
+        gecos: nss_safe(entry.gecos),
+        dir: nss_safe(entry.homedir),
+        shell: nss_safe(entry.shell),
     }
 }
 
 pub fn ak_group_to_group_entry(group: AKGroup) -> Group {
     Group {
-        name: group.name,
-        passwd: group.passwd,
+        name: nss_safe(group.name),
+        passwd: nss_safe(group.passwd),
         gid: group.gid,
-        members: group.members,
+        members: group.members.into_iter().map(nss_safe).collect(),
     }
 }
 
 pub fn shadow_entry(name: String) -> Shadow {
     Shadow {
-        name,
+        name: nss_safe(name),
         passwd: "x".to_owned(),
         last_change: -1,
         change_min_days: -1,
@@ -95,6 +109,43 @@ mod tests {
         let s = shadow_entry("alice".to_owned());
         assert_eq!(s.name, "alice");
         assert_eq!(s.passwd, "x");
+    }
+
+    /// An interior NUL would make libnss's `CString::new(..).expect(..)` panic
+    /// inside an `extern "C"` hook, aborting sshd or login.
+    #[test]
+    fn passwd_entry_strips_nul_bytes() {
+        let p = user_to_passwd_entry(User {
+            name: "ali\0ce".to_owned(),
+            uid: 1000,
+            gid: 100,
+            gecos: "Alice\0 Smith".to_owned(),
+            homedir: "/home/ali\0ce".to_owned(),
+            shell: "/bin/ba\0sh".to_owned(),
+        });
+        for field in [&p.name, &p.passwd, &p.gecos, &p.dir, &p.shell] {
+            assert!(!field.contains('\0'), "{field:?} still contains a NUL");
+        }
+        assert_eq!(p.name, "alice");
+        assert_eq!(p.shell, "/bin/bash");
+    }
+
+    #[test]
+    fn group_entry_strips_nul_bytes_including_members() {
+        let g = ak_group_to_group_entry(AKGroup {
+            name: "admi\0ns".to_owned(),
+            gid: 200,
+            passwd: "x\0".to_owned(),
+            members: vec!["ali\0ce".to_owned(), "bob".to_owned()],
+        });
+        assert_eq!(g.name, "admins");
+        assert_eq!(g.passwd, "x");
+        assert_eq!(g.members, vec!["alice".to_owned(), "bob".to_owned()]);
+    }
+
+    #[test]
+    fn shadow_entry_strips_nul_bytes() {
+        assert_eq!(shadow_entry("ali\0ce".to_owned()).name, "alice");
     }
 
     #[test]

--- a/ak-nss/src/passwd.rs
+++ b/ak-nss/src/passwd.rs
@@ -27,6 +27,7 @@ impl PasswdHooks for AuthentikNSS {
 fn get_all_entries_with(bridge: &impl DirectoryBridge) -> Response<Vec<Passwd>> {
     match bridge.list_users() {
         Ok(users) => Response::Success(users.into_iter().map(user_to_passwd_entry).collect()),
+        Err(GrpcError::NotFound) => Response::NotFound,
         Err(e) => {
             tracing::warn!("error getting users: {e:?}");
             Response::Unavail
@@ -40,6 +41,7 @@ fn get_entry_by_uid_with(bridge: &impl DirectoryBridge, uid: uid_t) -> Response<
         name: None,
     }) {
         Ok(user) => Response::Success(user_to_passwd_entry(user)),
+        Err(GrpcError::NotFound) => Response::NotFound,
         Err(e) => {
             tracing::warn!("error when getting user by ID '{uid}': {e:?}");
             Response::Unavail
@@ -58,6 +60,7 @@ fn get_entry_by_name_with(bridge: &impl DirectoryBridge, name: String) -> Respon
         id: None,
     }) {
         Ok(user) => Response::Success(user_to_passwd_entry(user)),
+        Err(GrpcError::NotFound) => Response::NotFound,
         Err(e) => {
             tracing::warn!("error when getting user by name '{name}': {e:?}");
             Response::Unavail

--- a/ak-nss/src/passwd.rs
+++ b/ak-nss/src/passwd.rs
@@ -4,6 +4,7 @@ use libnss::interop::Response;
 use libnss::passwd::{Passwd, PasswdHooks};
 
 use crate::AuthentikNSS;
+use crate::backend::ErrMap;
 use crate::backend::{DirectoryBridge, GrpcDirectoryBridge};
 use crate::mapping::user_to_passwd_entry;
 
@@ -25,28 +26,20 @@ impl PasswdHooks for AuthentikNSS {
 }
 
 fn get_all_entries_with(bridge: &impl DirectoryBridge) -> Response<Vec<Passwd>> {
-    match bridge.list_users() {
-        Ok(users) => Response::Success(users.into_iter().map(user_to_passwd_entry).collect()),
-        Err(GrpcError::NotFound) => Response::NotFound,
-        Err(e) => {
-            tracing::warn!("error getting users: {e:?}");
-            Response::Unavail
-        }
-    }
+    bridge
+        .list_users()
+        .map(|users| users.into_iter().map(user_to_passwd_entry).collect())
+        .to_response("failed to list users")
 }
 
 fn get_entry_by_uid_with(bridge: &impl DirectoryBridge, uid: uid_t) -> Response<Passwd> {
-    match bridge.get_user(GetRequest {
-        id: Some(uid),
-        name: None,
-    }) {
-        Ok(user) => Response::Success(user_to_passwd_entry(user)),
-        Err(GrpcError::NotFound) => Response::NotFound,
-        Err(e) => {
-            tracing::warn!("error when getting user by ID '{uid}': {e:?}");
-            Response::Unavail
-        }
-    }
+    bridge
+        .get_user(GetRequest {
+            id: Some(uid),
+            name: None,
+        })
+        .map(user_to_passwd_entry)
+        .to_response(format!("failed to get user by ID '{uid}'"))
 }
 
 fn get_entry_by_name_with(bridge: &impl DirectoryBridge, name: String) -> Response<Passwd> {
@@ -55,34 +48,30 @@ fn get_entry_by_name_with(bridge: &impl DirectoryBridge, name: String) -> Respon
     if name == "pam_unix_non_existent:" {
         return Response::NotFound;
     }
-    match bridge.get_user(GetRequest {
-        name: Some(name.clone()),
-        id: None,
-    }) {
-        Ok(user) => Response::Success(user_to_passwd_entry(user)),
-        Err(GrpcError::NotFound) => Response::NotFound,
-        Err(e) => {
-            tracing::warn!("error when getting user by name '{name}': {e:?}");
-            Response::Unavail
-        }
-    }
+    bridge
+        .get_user(GetRequest {
+            name: Some(name.clone()),
+            id: None,
+        })
+        .map(user_to_passwd_entry)
+        .to_response(format!("failed to get user by name '{name}'"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use ak_platform::generated::sys_directory::{Group as AKGroup, User};
-    use eyre::Result;
+    use ak_platform::grpc::{GrpcResult, Status};
 
     struct MockBridge {
         users: Vec<User>,
     }
 
     impl DirectoryBridge for MockBridge {
-        fn list_users(&self) -> Result<Vec<User>> {
+        fn list_users(&self) -> GrpcResult<Vec<User>> {
             Ok(self.users.clone())
         }
-        fn get_user(&self, req: GetRequest) -> Result<User> {
+        fn get_user(&self, req: GetRequest) -> GrpcResult<User> {
             self.users
                 .iter()
                 .find(|u| {
@@ -90,29 +79,46 @@ mod tests {
                         || req.name.as_deref().map_or(false, |n| n == u.name)
                 })
                 .cloned()
-                .ok_or_else(|| eyre::eyre!("not found"))
+                .ok_or_else(|| Status::not_found("no such entry").into())
         }
-        fn list_groups(&self) -> Result<Vec<AKGroup>> {
+        fn list_groups(&self) -> GrpcResult<Vec<AKGroup>> {
             unreachable!()
         }
-        fn get_group(&self, _req: GetRequest) -> Result<AKGroup> {
+        fn get_group(&self, _req: GetRequest) -> GrpcResult<AKGroup> {
             unreachable!()
         }
     }
 
-    struct ErrorBridge;
-    impl DirectoryBridge for ErrorBridge {
-        fn list_users(&self) -> Result<Vec<User>> {
-            Err(eyre::eyre!("unavailable"))
+    struct UnavailBridge;
+    impl DirectoryBridge for UnavailBridge {
+        fn list_users(&self) -> GrpcResult<Vec<User>> {
+            Err(Status::unavailable("connect failed").into())
         }
-        fn get_user(&self, _: GetRequest) -> Result<User> {
-            Err(eyre::eyre!("unavailable"))
+        fn get_user(&self, _: GetRequest) -> GrpcResult<User> {
+            Err(Status::unavailable("connect failed").into())
         }
-        fn list_groups(&self) -> Result<Vec<AKGroup>> {
+        fn list_groups(&self) -> GrpcResult<Vec<AKGroup>> {
             unreachable!()
         }
-        fn get_group(&self, _: GetRequest) -> Result<AKGroup> {
+        fn get_group(&self, _: GetRequest) -> GrpcResult<AKGroup> {
             unreachable!()
+        }
+    }
+
+    /// sysd answered, and there is no such entry.
+    struct NotFoundBridge;
+    impl DirectoryBridge for NotFoundBridge {
+        fn list_users(&self) -> GrpcResult<Vec<User>> {
+            Err(Status::not_found("no such entry").into())
+        }
+        fn get_user(&self, _: GetRequest) -> GrpcResult<User> {
+            Err(Status::not_found("no such entry").into())
+        }
+        fn list_groups(&self) -> GrpcResult<Vec<AKGroup>> {
+            Err(Status::not_found("no such entry").into())
+        }
+        fn get_group(&self, _: GetRequest) -> GrpcResult<AKGroup> {
+            Err(Status::not_found("no such entry").into())
         }
     }
 
@@ -146,7 +152,7 @@ mod tests {
     #[test]
     fn get_all_entries_unavail_on_error() {
         assert!(matches!(
-            get_all_entries_with(&ErrorBridge),
+            get_all_entries_with(&UnavailBridge),
             Response::Unavail
         ));
     }
@@ -165,7 +171,7 @@ mod tests {
     #[test]
     fn get_entry_by_uid_unavail_on_error() {
         assert!(matches!(
-            get_entry_by_uid_with(&ErrorBridge, 1000),
+            get_entry_by_uid_with(&UnavailBridge, 1000),
             Response::Unavail
         ));
     }
@@ -184,7 +190,7 @@ mod tests {
     #[test]
     fn get_entry_by_name_unavail_on_error() {
         assert!(matches!(
-            get_entry_by_name_with(&ErrorBridge, "alice".to_owned()),
+            get_entry_by_name_with(&UnavailBridge, "alice".to_owned()),
             Response::Unavail
         ));
     }
@@ -193,21 +199,54 @@ mod tests {
     fn pam_unix_non_existent_short_circuits_before_bridge() {
         struct PanicBridge;
         impl DirectoryBridge for PanicBridge {
-            fn list_users(&self) -> Result<Vec<User>> {
+            fn list_users(&self) -> GrpcResult<Vec<User>> {
                 panic!("bridge must not be called")
             }
-            fn get_user(&self, _: GetRequest) -> Result<User> {
+            fn get_user(&self, _: GetRequest) -> GrpcResult<User> {
                 panic!("bridge must not be called")
             }
-            fn list_groups(&self) -> Result<Vec<AKGroup>> {
+            fn list_groups(&self) -> GrpcResult<Vec<AKGroup>> {
                 panic!("bridge must not be called")
             }
-            fn get_group(&self, _: GetRequest) -> Result<AKGroup> {
+            fn get_group(&self, _: GetRequest) -> GrpcResult<AKGroup> {
                 panic!("bridge must not be called")
             }
         }
         assert!(matches!(
             get_entry_by_name_with(&PanicBridge, "pam_unix_non_existent:".to_owned()),
+            Response::NotFound
+        ));
+    }
+
+    /// A uid that simply isn't in the directory is NOTFOUND, not UNAVAIL.
+    #[test]
+    fn get_entry_by_uid_notfound_when_missing() {
+        let bridge = MockBridge {
+            users: vec![alice()],
+        };
+        assert!(matches!(
+            get_entry_by_uid_with(&bridge, 4242),
+            Response::NotFound
+        ));
+        assert!(matches!(
+            get_entry_by_uid_with(&NotFoundBridge, 4242),
+            Response::NotFound
+        ));
+    }
+
+    /// A name that simply isn't in the directory is NOTFOUND, not UNAVAIL — the
+    /// case that used to be misreported as a backend outage.
+    #[test]
+    fn get_entry_by_name_notfound_when_missing() {
+        let bridge = MockBridge {
+            users: vec![alice()],
+        };
+        assert!(matches!(
+            get_entry_by_name_with(&bridge, "bob".to_owned()),
+            Response::NotFound
+        ));
+        assert!(matches!(
+            get_entry_by_name_with(&NotFoundBridge, "bob".to_owned()),
             Response::NotFound
         ));
     }

--- a/ak-nss/src/shadow.rs
+++ b/ak-nss/src/shadow.rs
@@ -24,6 +24,7 @@ fn get_all_entries_with(bridge: &impl DirectoryBridge) -> Response<Vec<Shadow>> 
             let entries = users.into_iter().map(|u| shadow_entry(u.name)).collect();
             Response::Success(entries)
         }
+        Err(GrpcError::NotFound) => Response::NotFound,
         Err(e) => {
             tracing::warn!("Failed to get users: {e:?}");
             Response::Unavail
@@ -37,6 +38,7 @@ fn get_entry_by_name_with(bridge: &impl DirectoryBridge, name: String) -> Respon
         id: None,
     }) {
         Ok(user) => Response::Success(shadow_entry(user.name)),
+        Err(GrpcError::NotFound) => Response::NotFound,
         Err(e) => {
             tracing::warn!("Failed to get user by name '{name}': {e:?}");
             Response::Unavail

--- a/ak-nss/src/shadow.rs
+++ b/ak-nss/src/shadow.rs
@@ -3,6 +3,7 @@ use libnss::interop::Response;
 use libnss::shadow::{Shadow, ShadowHooks};
 
 use crate::AuthentikNSS;
+use crate::backend::ErrMap;
 use crate::backend::{DirectoryBridge, GrpcDirectoryBridge};
 use crate::mapping::shadow_entry;
 
@@ -19,75 +20,81 @@ impl ShadowHooks for AuthentikNSS {
 }
 
 fn get_all_entries_with(bridge: &impl DirectoryBridge) -> Response<Vec<Shadow>> {
-    match bridge.list_users() {
-        Ok(users) => {
-            let entries = users.into_iter().map(|u| shadow_entry(u.name)).collect();
-            Response::Success(entries)
-        }
-        Err(GrpcError::NotFound) => Response::NotFound,
-        Err(e) => {
-            tracing::warn!("Failed to get users: {e:?}");
-            Response::Unavail
-        }
-    }
+    bridge
+        .list_users()
+        .map(|users| users.into_iter().map(|u| shadow_entry(u.name)).collect())
+        .to_response("failed to list users")
 }
 
 fn get_entry_by_name_with(bridge: &impl DirectoryBridge, name: String) -> Response<Shadow> {
-    match bridge.get_user(GetRequest {
-        name: Some(name.clone()),
-        id: None,
-    }) {
-        Ok(user) => Response::Success(shadow_entry(user.name)),
-        Err(GrpcError::NotFound) => Response::NotFound,
-        Err(e) => {
-            tracing::warn!("Failed to get user by name '{name}': {e:?}");
-            Response::Unavail
-        }
-    }
+    bridge
+        .get_user(GetRequest {
+            name: Some(name.clone()),
+            id: None,
+        })
+        .map(|user| shadow_entry(user.name))
+        .to_response(format!("failed to get shadow entry for '{name}'"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use ak_platform::generated::sys_directory::{Group as AKGroup, User};
-    use eyre::Result;
+    use ak_platform::grpc::{GrpcResult, Status};
 
     struct MockBridge {
         users: Vec<User>,
     }
 
     impl DirectoryBridge for MockBridge {
-        fn list_users(&self) -> Result<Vec<User>> {
+        fn list_users(&self) -> GrpcResult<Vec<User>> {
             Ok(self.users.clone())
         }
-        fn get_user(&self, req: GetRequest) -> Result<User> {
+        fn get_user(&self, req: GetRequest) -> GrpcResult<User> {
             self.users
                 .iter()
                 .find(|u| req.name.as_deref().map_or(false, |n| n == u.name))
                 .cloned()
-                .ok_or_else(|| eyre::eyre!("not found"))
+                .ok_or_else(|| Status::not_found("no such entry").into())
         }
-        fn list_groups(&self) -> Result<Vec<AKGroup>> {
+        fn list_groups(&self) -> GrpcResult<Vec<AKGroup>> {
             unreachable!()
         }
-        fn get_group(&self, _req: GetRequest) -> Result<AKGroup> {
+        fn get_group(&self, _req: GetRequest) -> GrpcResult<AKGroup> {
             unreachable!()
         }
     }
 
-    struct ErrorBridge;
-    impl DirectoryBridge for ErrorBridge {
-        fn list_users(&self) -> Result<Vec<User>> {
-            Err(eyre::eyre!("unavailable"))
+    struct UnavailBridge;
+    impl DirectoryBridge for UnavailBridge {
+        fn list_users(&self) -> GrpcResult<Vec<User>> {
+            Err(Status::unavailable("connect failed").into())
         }
-        fn get_user(&self, _: GetRequest) -> Result<User> {
-            Err(eyre::eyre!("unavailable"))
+        fn get_user(&self, _: GetRequest) -> GrpcResult<User> {
+            Err(Status::unavailable("connect failed").into())
         }
-        fn list_groups(&self) -> Result<Vec<AKGroup>> {
+        fn list_groups(&self) -> GrpcResult<Vec<AKGroup>> {
             unreachable!()
         }
-        fn get_group(&self, _: GetRequest) -> Result<AKGroup> {
+        fn get_group(&self, _: GetRequest) -> GrpcResult<AKGroup> {
             unreachable!()
+        }
+    }
+
+    /// sysd answered, and there is no such entry.
+    struct NotFoundBridge;
+    impl DirectoryBridge for NotFoundBridge {
+        fn list_users(&self) -> GrpcResult<Vec<User>> {
+            Err(Status::not_found("no such entry").into())
+        }
+        fn get_user(&self, _: GetRequest) -> GrpcResult<User> {
+            Err(Status::not_found("no such entry").into())
+        }
+        fn list_groups(&self) -> GrpcResult<Vec<AKGroup>> {
+            Err(Status::not_found("no such entry").into())
+        }
+        fn get_group(&self, _: GetRequest) -> GrpcResult<AKGroup> {
+            Err(Status::not_found("no such entry").into())
         }
     }
 
@@ -121,7 +128,7 @@ mod tests {
     #[test]
     fn get_all_entries_unavail_on_error() {
         assert!(matches!(
-            get_all_entries_with(&ErrorBridge),
+            get_all_entries_with(&UnavailBridge),
             Response::Unavail
         ));
     }
@@ -143,8 +150,24 @@ mod tests {
     #[test]
     fn get_entry_by_name_unavail_on_error() {
         assert!(matches!(
-            get_entry_by_name_with(&ErrorBridge, "alice".to_owned()),
+            get_entry_by_name_with(&UnavailBridge, "alice".to_owned()),
             Response::Unavail
+        ));
+    }
+
+    /// A name that simply isn't in the directory is NOTFOUND, not UNAVAIL.
+    #[test]
+    fn get_entry_by_name_notfound_when_missing() {
+        let bridge = MockBridge {
+            users: vec![alice()],
+        };
+        assert!(matches!(
+            get_entry_by_name_with(&bridge, "bob".to_owned()),
+            Response::NotFound
+        ));
+        assert!(matches!(
+            get_entry_by_name_with(&NotFoundBridge, "bob".to_owned()),
+            Response::NotFound
         ));
     }
 }

--- a/ak-platform/src/client/user.rs
+++ b/ak-platform/src/client/user.rs
@@ -1,7 +1,6 @@
 use eyre::Result;
 use std::error::Error;
 use std::future::Future;
-use std::io::ErrorKind;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -17,7 +16,7 @@ use crate::{
         agent_ctrl::agent_ctrl_client::AgentCtrlClient, ping::ping_client::PingClient,
     },
     grpc::{
-        grpc_endpoint,
+        GrpcError, grpc_endpoint,
         ssh::{SSHService, SSHTunnel},
     },
     paths::{AgentSocketID, agent_socket_path},
@@ -94,32 +93,26 @@ impl Service<http::Request<tonic::body::Body>> for AnyService {
 
 impl Client<AnyService> {
     pub async fn new(path: Option<String>) -> Result<Self> {
-        let mut _path: String;
-        if let Some(_p) = path.clone() {
-            _path = _p;
-        } else {
-            _path = agent_socket_path(AgentSocketID::Default)?.for_current();
-        }
-        match grpc_endpoint(_path).await {
+        let socket = match &path {
+            Some(p) => p.clone(),
+            None => agent_socket_path(AgentSocketID::Default)?.for_current(),
+        };
+        match grpc_endpoint(socket).await {
             Ok(t) => Ok(Client {
                 c: AnyService(AnyServiceInner::Socket(t)),
             }),
-            Err(e) => {
-                // If we can't open the socket due to an IO Error of file not found,
-                // and we're trying to use the default socket path, attempt SSH connection
-                // If the user specified a path, then we return the error
-                if let Some(io_err) = e.downcast_ref::<std::io::Error>()
-                    && io_err.kind() == ErrorKind::NotFound
-                    && let None = path
-                    && std::env::var("SSH_AUTH_SOCK").is_ok()
-                {
-                    let service = SSHTunnel::new().await?.service(());
-                    return Ok(Client {
-                        c: AnyService(AnyServiceInner::Ssh(service)),
-                    });
-                }
-                Err(e)
+            // There is no socket at the default path, so the agent may still be
+            // reachable over a forwarded SSH agent socket. A path the caller
+            // asked for explicitly is taken at face value: its errors propagate.
+            Err(GrpcError::SocketNotFound())
+                if path.is_none() && std::env::var("SSH_AUTH_SOCK").is_ok() =>
+            {
+                let service = SSHTunnel::new().await?.service(());
+                Ok(Client {
+                    c: AnyService(AnyServiceInner::Ssh(service)),
+                })
             }
+            Err(e) => Err(e.into()),
         }
     }
 
@@ -163,5 +156,59 @@ where
 
     pub fn ping(self) -> PingClient<C> {
         PingClient::new(self.c)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MISSING: &str = "/nonexistent/ak-platform-test/agent.sock";
+
+    /// Guards the classification the SSH fallback depends on: dialing a path with
+    /// no socket must come back as `SocketNotFound`, which means the connector's
+    /// ENOENT really is reachable through `tonic::transport::Error`'s source
+    /// chain. If this regresses, `Client::new` never sees `SocketNotFound` and the
+    /// fallback goes quietly dead — which is exactly what it did while the error
+    /// passed through `eyre::Report`.
+    #[tokio::test]
+    async fn missing_socket_is_classified_as_socket_not_found() {
+        let err = grpc_endpoint(MISSING.to_string())
+            .await
+            .err()
+            .expect("dialing a missing socket must fail");
+        assert!(
+            matches!(err, GrpcError::SocketNotFound()),
+            "expected SocketNotFound, got {err:?}"
+        );
+    }
+
+    /// A dial that fails for some *other* reason must stay a `Transport` error and
+    /// keep the path in its message — the `From` impl can't supply one, so
+    /// `grpc_endpoint` has to classify with `from_dial`.
+    #[tokio::test]
+    async fn other_dial_failures_keep_the_path() {
+        // A directory is not a socket: connect(2) fails, but not with ENOENT.
+        let err = grpc_endpoint("/tmp".to_string())
+            .await
+            .err()
+            .expect("dialing a directory must fail");
+        match err {
+            GrpcError::Transport(_, path) => assert_eq!(path, "/tmp"),
+            GrpcError::SocketNotFound() => panic!("ENOENT misreported for an existing path"),
+            other => panic!("expected Transport, got {other:?}"),
+        }
+    }
+
+    /// A path the caller asked for explicitly must surface its own error rather
+    /// than diverting to SSH — including on a dev machine where SSH_AUTH_SOCK is
+    /// set, which is why the guard checks `path.is_none()` first.
+    #[tokio::test]
+    async fn explicit_path_does_not_fall_back_to_ssh() {
+        assert!(
+            Client::<AnyService>::new(Some(MISSING.to_string()))
+                .await
+                .is_err()
+        );
     }
 }

--- a/ak-platform/src/grpc/mod.rs
+++ b/ak-platform/src/grpc/mod.rs
@@ -2,9 +2,11 @@ use base64::{Engine, prelude::BASE64_STANDARD};
 use eyre::Report;
 use eyre::Result;
 use eyre::bail;
+use std::error::Error;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::future::Future;
+use std::io::ErrorKind;
 use tokio::runtime::{Builder, Runtime};
 use tonic::transport::Uri;
 use tonic::transport::{Channel, Endpoint};
@@ -19,35 +21,68 @@ pub mod log;
 pub mod method_caller;
 pub mod ssh;
 
+pub use tonic::Code;
+pub use tonic::Status;
+
 pub type GrpcResult<T> = std::result::Result<T, GrpcError>;
 
 #[derive(Debug)]
 pub enum GrpcError {
-    NotFound,
-    InvalidArgument,
-    PermissionDenied,
-    Internal,
-    Unavailable,
+    Status(tonic::Status),
     Transport(tonic::transport::Error, String),
+    SocketNotFound(),
     Other(Report),
 }
 
 impl Display for GrpcError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            GrpcError::NotFound => write!(f, "Not found"),
-            GrpcError::InvalidArgument => write!(f, "invalid argument"),
-            GrpcError::PermissionDenied => write!(f, "permission denied"),
-            GrpcError::Internal => write!(f, "internal"),
-            GrpcError::Unavailable => write!(f, "unavailable"),
+            GrpcError::Status(s) => s.fmt(f),
             GrpcError::Transport(error, path) => {
                 write!(f, "error connecting to {}: {:?}", path, error)
             }
+            GrpcError::SocketNotFound() => write!(f, "socket not found"),
             GrpcError::Other(report) => report.fmt(f),
         }
     }
 }
 impl std::error::Error for GrpcError {}
+
+impl From<tonic::Status> for GrpcError {
+    fn from(value: tonic::Status) -> Self {
+        GrpcError::Status(value)
+    }
+}
+
+impl GrpcError {
+    /// Whether a failed dial means "there is no socket at that path".
+    ///
+    /// `tonic::transport::Error` holds the connector's `io::Error` down its
+    /// `source()` chain rather than exposing it directly, so the ENOENT is only
+    /// visible by walking it.
+    fn socket_missing(e: &tonic::transport::Error) -> bool {
+        let mut cur: Option<&(dyn Error + 'static)> = Some(e);
+        while let Some(err) = cur {
+            if let Some(io_err) = err.downcast_ref::<std::io::Error>() {
+                return io_err.kind() == ErrorKind::NotFound;
+            }
+            cur = err.source();
+        }
+        false
+    }
+
+    /// Classifies a failed dial, keeping `path` for the error message.
+    ///
+    /// Prefer this over `From<tonic::transport::Error>` wherever the path is
+    /// known — the `From` impl has to leave it blank.
+    fn from_dial(e: tonic::transport::Error, path: String) -> Self {
+        if GrpcError::socket_missing(&e) {
+            GrpcError::SocketNotFound()
+        } else {
+            GrpcError::Transport(e, path)
+        }
+    }
+}
 
 pub async fn grpc_endpoint(path: String) -> GrpcResult<Channel> {
     // Dummy URI to satisfy Endpoint::from() type requirements
@@ -61,7 +96,7 @@ pub async fn grpc_endpoint(path: String) -> GrpcResult<Channel> {
     let endpoint = Endpoint::from(u);
     let channel = grpc_dial(endpoint, path.clone())
         .await
-        .map_err(|e| GrpcError::Transport(e, path))?;
+        .map_err(|e| GrpcError::from_dial(e, path))?;
     Ok(channel)
 }
 

--- a/ak-platform/src/grpc/mod.rs
+++ b/ak-platform/src/grpc/mod.rs
@@ -1,7 +1,9 @@
 use base64::{Engine, prelude::BASE64_STANDARD};
-use eyre::Context;
+use eyre::Report;
 use eyre::Result;
 use eyre::bail;
+use std::fmt::Display;
+use std::fmt::Formatter;
 use std::future::Future;
 use tokio::runtime::{Builder, Runtime};
 use tonic::transport::Uri;
@@ -17,18 +19,49 @@ pub mod log;
 pub mod method_caller;
 pub mod ssh;
 
-pub async fn grpc_endpoint(path: String) -> Result<Channel> {
+pub type GrpcResult<T> = std::result::Result<T, GrpcError>;
+
+#[derive(Debug)]
+pub enum GrpcError {
+    NotFound,
+    InvalidArgument,
+    PermissionDenied,
+    Internal,
+    Unavailable,
+    Transport(tonic::transport::Error, String),
+    Other(Report),
+}
+
+impl Display for GrpcError {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            GrpcError::NotFound => write!(f, "Not found"),
+            GrpcError::InvalidArgument => write!(f, "invalid argument"),
+            GrpcError::PermissionDenied => write!(f, "permission denied"),
+            GrpcError::Internal => write!(f, "internal"),
+            GrpcError::Unavailable => write!(f, "unavailable"),
+            GrpcError::Transport(error, path) => {
+                write!(f, "error connecting to {}: {:?}", path, error)
+            }
+            GrpcError::Other(report) => report.fmt(f),
+        }
+    }
+}
+impl std::error::Error for GrpcError {}
+
+pub async fn grpc_endpoint(path: String) -> GrpcResult<Channel> {
     // Dummy URI to satisfy Endpoint::from() type requirements
     // The connector ignores this and uses the socket_path parameter directly
     let u = Uri::builder()
         .scheme("http")
         .authority(":123")
         .path_and_query("/")
-        .build()?;
+        .build()
+        .map_err(|e| GrpcError::Other(e.into()))?;
     let endpoint = Endpoint::from(u);
     let channel = grpc_dial(endpoint, path.clone())
         .await
-        .context(format!("failed to connect to {path}"))?;
+        .map_err(|e| GrpcError::Transport(e, path))?;
     Ok(channel)
 }
 
@@ -47,17 +80,22 @@ async fn grpc_dial(
         .await;
 }
 
-pub fn grpc_request<T, F: Future<Output = Result<T>>>(future: impl Fn(Channel) -> F) -> Result<T> {
+pub fn grpc_request<T, F: Future<Output = GrpcResult<T>>>(
+    future: impl Fn(Channel) -> F,
+) -> GrpcResult<T> {
     let config = Config::get();
 
     grpc_request_path(config.socket_default.for_current().to_owned(), future)
 }
 
-pub fn grpc_request_path<T, F: Future<Output = Result<T>>>(
+pub fn grpc_request_path<T, F: Future<Output = GrpcResult<T>>>(
     path: String,
     future: impl Fn(Channel) -> F,
-) -> Result<T> {
-    let rt = Builder::new_current_thread().enable_all().build()?;
+) -> GrpcResult<T> {
+    let rt = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| GrpcError::Other(e.into()))?;
 
     rt.block_on(async {
         let channel = grpc_endpoint(path).await?;
@@ -66,15 +104,15 @@ pub fn grpc_request_path<T, F: Future<Output = Result<T>>>(
 }
 
 pub trait SysdBridge {
-    fn grpc_request<T, F: Future<Output = Result<T>>>(
+    fn grpc_request<T, F: Future<Output = GrpcResult<T>>>(
         &self,
         future: impl Fn(Channel) -> F,
-    ) -> Result<T>;
-    fn grpc_request_path<T, F: Future<Output = Result<T>>>(
+    ) -> GrpcResult<T>;
+    fn grpc_request_path<T, F: Future<Output = GrpcResult<T>>>(
         &self,
         path: String,
         future: impl Fn(Channel) -> F,
-    ) -> Result<T>;
+    ) -> GrpcResult<T>;
 }
 
 pub struct Bridge {
@@ -89,20 +127,20 @@ impl Bridge {
 }
 
 impl SysdBridge for Bridge {
-    fn grpc_request<T, F: Future<Output = Result<T>>>(
+    fn grpc_request<T, F: Future<Output = GrpcResult<T>>>(
         &self,
         future: impl Fn(Channel) -> F,
-    ) -> Result<T> {
+    ) -> GrpcResult<T> {
         let config = Config::get();
 
         self.grpc_request_path(config.socket_default.for_current().to_owned(), future)
     }
 
-    fn grpc_request_path<T, F: Future<Output = Result<T>>>(
+    fn grpc_request_path<T, F: Future<Output = GrpcResult<T>>>(
         &self,
         path: String,
         future: impl Fn(Channel) -> F,
-    ) -> Result<T> {
+    ) -> GrpcResult<T> {
         self.rt.block_on(async {
             tracing::debug!("creating grpc client");
             let channel = grpc_endpoint(path).await?;

--- a/ak-platform/src/grpc/ssh/mod.rs
+++ b/ak-platform/src/grpc/ssh/mod.rs
@@ -128,11 +128,17 @@ where
                 }
             };
 
-            // Required as the inner message is also SSH encoded as a whole
-            let mut raw_bytes = raw_res.details.into_bytes();
-            raw_bytes.drain(0..4);
+            // Response wire (ext_ak.rs `handle_agent_tunnel`): a single type-tag
+            // byte, then the ExtAuthentikAgentTunnelData payload. The server also
+            // legitimately answers with an *empty* response on its failure paths
+            // (decode/gRPC-server/call failures), so check length before slicing
+            // off the tag instead of unconditionally draining a fixed prefix.
+            let raw_bytes = raw_res.details.into_bytes();
+            let Some(inner) = raw_bytes.get(1..) else {
+                return Err(Box::from("empty tunnel response"));
+            };
 
-            let res = match ExtAuthentikAgentTunnelData::deserialize(&raw_bytes) {
+            let res = match ExtAuthentikAgentTunnelData::deserialize(inner) {
                 Some(d) => d,
                 None => return Err(Box::from("failed to parse response")),
             };
@@ -172,6 +178,11 @@ mod tests {
 
     // --- Integration test: full gRPC-over-SSH-tunnel flow ---
 
+    /// The real response-type tag `ak-agent/src/ssh/ext_ak.rs` (`handle_agent_tunnel`)
+    /// prepends to every non-empty response, ahead of the ExtAuthentikAgentTunnelData
+    /// payload.
+    const SSH_AGENT_EXT_RESPONSE_TYPE: u8 = 29;
+
     #[derive(Clone, Default)]
     struct MockTunnelAgent;
 
@@ -187,16 +198,32 @@ mod tests {
             }
             .serialize();
 
-            // mod.rs drains the first 4 bytes of the response before deserializing,
-            // matching the SSH encoding convention where extension bodies carry a
-            // u32 length prefix.
-            let mut prefixed = Vec::with_capacity(4 + serialized.len());
-            prefixed.extend_from_slice(&(serialized.len() as u32).to_be_bytes());
+            // Mirrors the real server's wire format: a single type-tag byte
+            // ahead of the payload, not a length prefix over the whole thing.
+            let mut prefixed = Vec::with_capacity(1 + serialized.len());
+            prefixed.push(SSH_AGENT_EXT_RESPONSE_TYPE);
             prefixed.extend_from_slice(&serialized);
 
             Ok(Some(Extension {
                 name: EXT_AUTHENTIK_AGENT_TUNNEL.to_string(),
                 details: Unparsed::from(prefixed),
+            }))
+        }
+    }
+
+    /// Mirrors `ext_ak.rs`'s `handle_agent_tunnel` on any of its failure paths
+    /// (request-decode failure, gRPC-server-creation failure, method-call
+    /// failure): it always answers with an empty `details`, not a shorter
+    /// valid payload.
+    #[derive(Clone, Default)]
+    struct EmptyResponseAgent;
+
+    #[ssh_agent_lib::async_trait]
+    impl Session for EmptyResponseAgent {
+        async fn extension(&mut self, _ext: Extension) -> Result<Option<Extension>, AgentError> {
+            Ok(Some(Extension {
+                name: EXT_AUTHENTIK_AGENT_TUNNEL.to_string(),
+                details: Unparsed::from(Vec::new()),
             }))
         }
     }
@@ -248,6 +275,52 @@ mod tests {
         let body_bytes = resp.into_body().collect().await?.to_bytes();
         let stripped = grpc_unframe(&body_bytes)?;
         assert_eq!(stripped, proto_payload);
+
+        server_handle.abort();
+        let _ = server_handle.await;
+        let _ = std::fs::remove_file(sock_path);
+
+        Ok(())
+    }
+
+    /// Regression test: an empty tunnel response (what the real server sends
+    /// on every one of its failure paths) used to panic with "range end index
+    /// 4 out of range for slice of length 0" from an unconditional
+    /// `Vec::drain(0..4)`. It must surface as an `Err` instead.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn ssh_service_errors_instead_of_panicking_on_empty_response()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        use interprocess::local_socket::{
+            GenericFilePath,
+            tokio::{Stream as LocalSocketStream, prelude::*},
+        };
+        use ssh_agent_lib::client::Client;
+        use tokio::net::UnixListener;
+
+        let sock_path = "/tmp/ak-test-grpc-ssh-empty-response.sock";
+        let _ = std::fs::remove_file(sock_path);
+
+        let listener = UnixListener::bind(sock_path)?;
+        let server_handle =
+            tokio::spawn(async move { ssh_listen(listener, EmptyResponseAgent).await });
+
+        let name = sock_path.to_fs_name::<GenericFilePath>()?;
+        let stream = LocalSocketStream::connect(name).await?;
+        let client = Client::new(stream);
+
+        let tunnel = SSHTunnel {
+            client: Arc::new(Mutex::new(client)),
+        };
+        let mut svc = tunnel.service(());
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/some.Service/Method")
+            .header("content-type", "application/grpc+proto")
+            .body(Full::new(Bytes::from(grpc_frame(&[0x01]))))?;
+
+        assert!(svc.call(req).await.is_err());
 
         server_handle.abort();
         let _ = server_handle.await;

--- a/ak-platform/src/grpc/ssh/mod.rs
+++ b/ak-platform/src/grpc/ssh/mod.rs
@@ -35,7 +35,7 @@ impl SSHTunnel {
             std::env::var("SSH_AUTH_SOCK").map_err(|_| eyre::eyre!("SSH_AUTH_SOCK is not set"))?;
         let st = match connect(PlatformString::new_with_default(&sock_path)).await {
             Ok(s) => s,
-            Err(e) => return Err(e),
+            Err(e) => return Err(e.into()),
         };
         let client = Client::new(st.into_inner());
         Ok(SSHTunnel {

--- a/ak-platform/src/net/client/mod.rs
+++ b/ak-platform/src/net/client/mod.rs
@@ -1,4 +1,3 @@
-use eyre::Result;
 use hyper_util::rt::TokioIo;
 use interprocess::local_socket::{
     GenericFilePath,
@@ -7,7 +6,7 @@ use interprocess::local_socket::{
 
 use crate::string::PlatformString;
 
-pub async fn connect(path: PlatformString) -> Result<TokioIo<LocalSocketStream>> {
+pub async fn connect(path: PlatformString) -> std::io::Result<TokioIo<LocalSocketStream>> {
     let name = path.for_current().to_fs_name::<GenericFilePath>()?;
 
     let stream = LocalSocketStream::connect(name).await?;


### PR DESCRIPTION
not found should not result in a warning and should return the correct NSS response