### PR TITLE
ak-pam: remove hardcoded password requirement

### DIFF
--- a/ak-pam/src/auth.rs
+++ b/ak-pam/src/auth.rs
@@ -20,8 +20,6 @@ pub mod authorize;
 pub mod fido;
 pub mod interactive;
 
-pub const PW_PROMPT: &str = "authentik Password: ";
-
 pub fn authenticate_impl(
     pamh: &mut PamHandle,
     _args: Vec<&CStr>,
@@ -62,22 +60,6 @@ pub fn authenticate_impl(
         }
     };
     log::debug!("Started conv");
-    let password = match pam_try_log!(
-        conv.send(PAM_PROMPT_ECHO_OFF, PW_PROMPT),
-        "failed to send prompt"
-    ) {
-        Some(password) => match password.as_str() {
-            Ok(t) => t.to_owned(),
-            Err(_) => {
-                log::warn!("failed to convert password");
-                return PamResultCode::PAM_AUTH_ERR;
-            }
-        },
-        None => {
-            log::warn!("No password!");
-            return PamResultCode::PAM_AUTH_ERR;
-        }
-    };
 
     let session_data = SessionData {
         username: username.to_string(),
@@ -93,7 +75,7 @@ pub fn authenticate_impl(
     };
 
     log::debug!("Interactive authentication");
-    let int_res = match auth_interactive(username, password.to_owned(), &conv, bridge) {
+    let int_res = match auth_interactive(username, &conv, bridge) {
         Ok(ss) => ss,
         Err(code) => return code,
     };

--- a/ak-pam/src/auth/interactive.rs
+++ b/ak-pam/src/auth/interactive.rs
@@ -12,7 +12,6 @@ use pam::{
     conv::Conv,
 };
 
-use crate::auth::PW_PROMPT;
 use crate::auth::fido::fido2;
 
 const MAX_ITER: i8 = 30;
@@ -40,7 +39,6 @@ pub fn prompt_meta_to_pam_message_style(challenge: &InteractiveChallenge) -> Pam
 
 pub fn auth_interactive(
     username: String,
-    password: String,
     conv: &Conv<'_>,
     bridge: impl SysdBridge,
 ) -> Result<InteractiveChallenge, PamResultCode> {
@@ -50,7 +48,6 @@ pub fn auth_interactive(
             .interactive_auth(InteractiveAuthRequest {
                 interactive_auth: Some(InteractiveAuth::Init(InteractiveAuthInitRequest {
                     username: username.to_owned(),
-                    password: password.to_owned(),
                 })),
             })
             .await?);
@@ -61,14 +58,11 @@ pub fn auth_interactive(
             return Err(PamResultCode::PAM_AUTH_ERR);
         }
     };
-    // We always prompt for password to distinguish between token/interactive
-    // so at this point we've always statically prompted for password.
-    // In case this initial prompt from the server fails, re-attempt the password challenge
     let mut prev_challenge = InteractiveChallenge {
         txid: challenge.txid.to_owned(),
         finished: false,
         result: 0,
-        prompt: PW_PROMPT.to_owned(),
+        prompt: "".to_owned(),
         prompt_meta: PAM_PROMPT_ECHO_OFF,
         debug_info: "".to_owned(),
         session_id: "".to_owned(),

--- a/ak-platform/src/generated/sys_auth/sys_auth.rs
+++ b/ak-platform/src/generated/sys_auth/sys_auth.rs
@@ -34,8 +34,6 @@ pub struct SshCertAuthResponse {
 pub struct InteractiveAuthInitRequest {
     #[prost(string, tag="1")]
     pub username: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub password: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct InteractiveAuthContinueRequest {

--- a/ak-platform/src/generated/sys_auth/sys_auth.serde.rs
+++ b/ak-platform/src/generated/sys_auth/sys_auth.serde.rs
@@ -227,15 +227,9 @@ impl serde::Serialize for InteractiveAuthInitRequest {
         if !self.username.is_empty() {
             len += 1;
         }
-        if !self.password.is_empty() {
-            len += 1;
-        }
         let mut struct_ser = serializer.serialize_struct("sys_auth.InteractiveAuthInitRequest", len)?;
         if !self.username.is_empty() {
             struct_ser.serialize_field("username", &self.username)?;
-        }
-        if !self.password.is_empty() {
-            struct_ser.serialize_field("password", &self.password)?;
         }
         struct_ser.end()
     }
@@ -248,13 +242,11 @@ impl<'de> serde::Deserialize<'de> for InteractiveAuthInitRequest {
     {
         const FIELDS: &[&str] = &[
             "username",
-            "password",
         ];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Username,
-            Password,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -277,7 +269,6 @@ impl<'de> serde::Deserialize<'de> for InteractiveAuthInitRequest {
                     {
                         match value {
                             "username" => Ok(GeneratedField::Username),
-                            "password" => Ok(GeneratedField::Password),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -298,7 +289,6 @@ impl<'de> serde::Deserialize<'de> for InteractiveAuthInitRequest {
                     V: serde::de::MapAccess<'de>,
             {
                 let mut username__ = None;
-                let mut password__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Username => {
@@ -307,17 +297,10 @@ impl<'de> serde::Deserialize<'de> for InteractiveAuthInitRequest {
                             }
                             username__ = Some(map_.next_value()?);
                         }
-                        GeneratedField::Password => {
-                            if password__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("password"));
-                            }
-                            password__ = Some(map_.next_value()?);
-                        }
                     }
                 }
                 Ok(InteractiveAuthInitRequest {
                     username: username__.unwrap_or_default(),
-                    password: password__.unwrap_or_default(),
                 })
             }
         }

--- a/ak-sysd/src/components/auth/interactive/interactive_txn.rs
+++ b/ak-sysd/src/components/auth/interactive/interactive_txn.rs
@@ -40,8 +40,6 @@ pub struct InteractiveAuthTransaction {
     domain: Arc<LoadedDomain>,
     fex: FlowExecutor,
     username: String,
-    // Init password, submitted once then cleared.
-    password: Option<String>,
 }
 
 impl InteractiveAuthTransaction {
@@ -51,7 +49,6 @@ impl InteractiveAuthTransaction {
         domain: Arc<LoadedDomain>,
         flow_slug: String,
         username: String,
-        password: String,
     ) -> Result<Self, Status> {
         let mut fex = FlowExecutor::builder()
             .flow(flow_slug)
@@ -71,7 +68,6 @@ impl InteractiveAuthTransaction {
             domain,
             fex,
             username,
-            password: Some(password).filter(|p| !p.is_empty()),
         })
     }
 
@@ -112,12 +108,6 @@ impl InteractiveAuthTransaction {
                 })
             }
             ChallengeTypes::AkStagePassword(_) => {
-                if let Some(password) = self.password.take() {
-                    if let Some(err) = self.solve_challenge(password).await? {
-                        return Ok(err);
-                    }
-                    return Box::pin(self.get_next_challenge()).await;
-                }
                 Ok(InteractiveChallenge {
                     txid: self.id.clone(),
                     prompt: PASSWORD_PROMPT.to_string(),
@@ -280,14 +270,13 @@ mod tests {
         })
     }
 
-    async fn new_txn(server: &Server, password: &str) -> InteractiveAuthTransaction {
+    async fn new_txn(server: &Server) -> InteractiveAuthTransaction {
         InteractiveAuthTransaction::new(
             "test-txid".to_string(),
             test_context().await,
             test_domain(server),
             "test-flow".to_string(),
             "akadmin".to_string(),
-            password.to_string(),
         )
         .await
         .unwrap()
@@ -343,7 +332,17 @@ mod tests {
             }),
         );
 
-        let mut txn = new_txn(&server, "hunter2").await;
+        let mut txn = new_txn(&server).await;
+        let challenge = txn.get_next_challenge().await.unwrap();
+
+        assert!(!challenge.finished);
+        assert_eq!(challenge.component, "ak-stage-password");
+        assert_eq!(challenge.prompt, PASSWORD_PROMPT);
+        assert_eq!(challenge.prompt_meta, PromptMeta::PamPromptEchoOff as i32);
+
+        let err = txn.solve_challenge("hunter2".to_string()).await.unwrap();
+        assert!(err.is_none());
+
         let challenge = txn.get_next_challenge().await.unwrap();
 
         assert!(challenge.finished);
@@ -386,7 +385,17 @@ mod tests {
             )),
         );
 
-        let mut txn = new_txn(&server, "hunter2").await;
+        let mut txn = new_txn(&server).await;
+        let challenge = txn.get_next_challenge().await.unwrap();
+
+        assert!(!challenge.finished);
+        assert_eq!(challenge.component, "ak-stage-password");
+        assert_eq!(challenge.prompt, PASSWORD_PROMPT);
+        assert_eq!(challenge.prompt_meta, PromptMeta::PamPromptEchoOff as i32);
+
+        let err = txn.solve_challenge("hunter2".to_string()).await.unwrap();
+        assert!(err.is_none());
+
         let challenge = txn.get_next_challenge().await.unwrap();
 
         assert!(!challenge.finished);
@@ -398,10 +407,25 @@ mod tests {
         let server = Server::run();
         expect_flow_get(&server, identification_challenge(true));
 
-        let mut txn = new_txn(&server, "hunter2").await;
+        let mut txn = new_txn(&server).await;
         let challenge = txn.get_next_challenge().await.unwrap();
 
         assert!(!challenge.finished);
         assert!(challenge.prompt.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_next_challenge_returns_password_prompt_for_password_stage() {
+        let server = Server::run();
+        expect_flow_get(&server, identification_challenge(false));
+        expect_flow_solve(&server, "ak-stage-identification", password_challenge());
+
+        let mut txn = new_txn(&server).await;
+        let challenge = txn.get_next_challenge().await.unwrap();
+
+        assert!(!challenge.finished);
+        assert_eq!(challenge.component, "ak-stage-password");
+        assert_eq!(challenge.prompt, PASSWORD_PROMPT);
+        assert_eq!(challenge.prompt_meta, PromptMeta::PamPromptEchoOff as i32);
     }
 }

--- a/ak-sysd/src/components/auth/interactive/mod.rs
+++ b/ak-sysd/src/components/auth/interactive/mod.rs
@@ -84,7 +84,6 @@ async fn interactive_auth_init(
         Arc::clone(&active),
         flow_slug,
         init.username,
-        init.password,
     )
     .await?;
 

--- a/ee/psso/Bridge/Generated/sys_auth.pb.swift
+++ b/ee/psso/Bridge/Generated/sys_auth.pb.swift
@@ -132,8 +132,6 @@ nonisolated struct InteractiveAuthInitRequest: Sendable {
 
   var username: String = String()
 
-  var password: String = String()
-
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -490,7 +488,7 @@ nonisolated extension SSHCertAuthResponse: SwiftProtobuf.Message, SwiftProtobuf.
 
 nonisolated extension InteractiveAuthInitRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".InteractiveAuthInitRequest"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}username\0\u{1}password\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}username\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -499,7 +497,6 @@ nonisolated extension InteractiveAuthInitRequest: SwiftProtobuf.Message, SwiftPr
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.username) }()
-      case 2: try { try decoder.decodeSingularStringField(value: &self.password) }()
       default: break
       }
     }
@@ -509,15 +506,11 @@ nonisolated extension InteractiveAuthInitRequest: SwiftProtobuf.Message, SwiftPr
     if !self.username.isEmpty {
       try visitor.visitSingularStringField(value: self.username, fieldNumber: 1)
     }
-    if !self.password.isEmpty {
-      try visitor.visitSingularStringField(value: self.password, fieldNumber: 2)
-    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: InteractiveAuthInitRequest, rhs: InteractiveAuthInitRequest) -> Bool {
     if lhs.username != rhs.username {return false}
-    if lhs.password != rhs.password {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/protobuf/sys_auth.proto
+++ b/protobuf/sys_auth.proto
@@ -48,7 +48,6 @@ message SSHCertAuthResponse {
 
 message InteractiveAuthInitRequest {
   string username = 1;
-  string password = 2;
 }
 
 message InteractiveAuthContinueRequest {


### PR DESCRIPTION
not actually required anymore since we removed `ak ssh` (https://github.com/goauthentik/platform/pull/935)