### PR TITLE
Fix arguments in ak-sysd plist file

### DIFF
--- a/vpkg/macos/scripts/daemon.plist
+++ b/vpkg/macos/scripts/daemon.plist
@@ -7,9 +7,9 @@
 	<key>ProgramArguments</key>
 	<array>
 		<string>/Applications/authentik Agent.app/Contents/MacOS/ak-sysd</string>
-        <string>agent</string>
-        <string>--config-file</string>
+        <string>--config</string>
         <string>/opt/authentik/config/config.json</string>
+        <string>agent</string>
 	</array>
 	<key>UserName</key>
 	<string>root</string>


### PR DESCRIPTION
The plist is trying to make ak-sysd call the old --config-file instead of the new --config so it errors on startup and crashes