### PR TITLE
ee/psso: send a valid :authority over the sysd unix socket

### DIFF
--- a/ee/psso/Bridge/SysdBridge.swift
+++ b/ee/psso/Bridge/SysdBridge.swift
@@ -75,7 +75,14 @@ public class SysdBridge {
         return try await withGRPCClient(
             transport: .http2NIOPosix(
                 target: .unixDomainSocket(path: self.getSocketPath(id: id)),
-                transportSecurity: .plaintext
+                transportSecurity: .plaintext,
+                // For a Unix-domain target grpc-swift defaults :authority to the
+                // percent-encoded socket path, which Rust's h2 rejects as an
+                // invalid authority with RST_STREAM(PROTOCOL_ERROR) before tonic
+                // ever sees the request. Pin it to a valid value instead.
+                config: .defaults { config in
+                    config.http2.authority = "localhost"
+                }
             ),
             interceptors: [self.logInterceptor],
             handleClient: handleClient,


### PR DESCRIPTION
When PSSO and ak-sysd tried to communicate over a unix socket, the authority header would get set to the socket `%2Fvar%2Frun%2Fauthentik-sysd.sock`. This caused the call to fail due to an invalid authority header. Setting it to localhost gives an allowed value