### PR TITLE
ak-sysd: make managed-domain selection and lifecycle deterministic

### DIFF
--- a/ak-sysd/src/cfg/domain.rs
+++ b/ak-sysd/src/cfg/domain.rs
@@ -216,22 +216,36 @@ impl DomainManager {
     /// for single-tenant components (ping, auth, directory, device). Do not
     /// invent smarter "current domain" selection here.
     ///
+    /// An MDM-managed domain wins when there is one: it carries the connector
+    /// and device group the organisation assigned, whereas a hand-run
+    /// `domains join` may point somewhere else entirely. Policy beats ad hoc.
+    ///
     /// The token check matters because `load_managed` adds an MDM-managed
     /// domain alongside any user-enrolled ones. If its enrollment produced no
     /// token, it is still `enabled`, and returning it means every request goes
     /// out as `Bearer+agent ` and comes back 403 "Authentication credentials
     /// were not provided" — while a perfectly good domain sits further down the
     /// list.
+    ///
+    /// Note this still only ever returns one domain, while the storage layer
+    /// happily holds several. Every auth path (`ping`, `auth/*`, `session`,
+    /// `directory`) calls this and silently ignores the rest; only `device`
+    /// check-in and `healthcheck_all` fan out. Making multi-domain genuinely
+    /// work means binding a domain to each of those call sites.
     pub async fn active(&self) -> Result<Arc<LoadedDomain>> {
-        let selected = self
-            .domains
-            .read()
-            .await
+        let domains = self.domains.read().await;
+        let usable = |d: &&Arc<LoadedDomain>| d.cfg.enabled && !d.cfg.token.is_empty();
+        let selected = domains
             .iter()
-            .find(|d| d.cfg.enabled && !d.cfg.token.is_empty())
+            .find(|d| usable(d) && d.cfg.managed)
+            .or_else(|| domains.iter().find(usable))
             .cloned()
             .ok_or_else(|| eyre!("no enabled domain with a token configured"))?;
-        tracing::debug!(domain = %selected.cfg.domain, "selected active domain");
+        tracing::debug!(
+            domain = %selected.cfg.domain,
+            managed = selected.cfg.managed,
+            "selected active domain"
+        );
         Ok(selected)
     }
 
@@ -380,11 +394,25 @@ impl DomainManager {
     /// Loads (or re-enrolls, or removes) the MDM-managed domain. See
     /// `cfg::managed` for the platform-specific config source.
     pub async fn load_managed(&self) -> Result<()> {
+        const MANAGED_DOMAIN_NAME: &str = "ak-mdm-managed";
+
         let Some(managed) = crate::cfg::managed::load_managed_config()? else {
+            // No managed config means the profile is gone, so a managed domain
+            // left behind is stale policy. `load_all` reloads every `*.json`
+            // regardless of whether the config that created it still exists, so
+            // without this the domain lingers forever — never refreshed, never
+            // revoked, and still competing to be the active one.
+            if self
+                .domains()
+                .await
+                .iter()
+                .any(|d| d.cfg.domain == MANAGED_DOMAIN_NAME)
+            {
+                tracing::info!("managed config absent, removing managed domain");
+                self.delete_domain(MANAGED_DOMAIN_NAME).await?;
+            }
             return Ok(());
         };
-
-        const MANAGED_DOMAIN_NAME: &str = "ak-mdm-managed";
         let existing = self
             .domains()
             .await

--- a/ak-sysd/src/cfg/domain.rs
+++ b/ak-sysd/src/cfg/domain.rs
@@ -212,17 +212,27 @@ impl DomainManager {
         refresh_interval
     }
 
-    /// First enabled domain — mirrors Go's `dom[0]` shortcut for
-    /// single-tenant components (ping, auth, directory, device). Do not
+    /// First enabled domain that has a token — mirrors Go's `dom[0]` shortcut
+    /// for single-tenant components (ping, auth, directory, device). Do not
     /// invent smarter "current domain" selection here.
+    ///
+    /// The token check matters because `load_managed` adds an MDM-managed
+    /// domain alongside any user-enrolled ones. If its enrollment produced no
+    /// token, it is still `enabled`, and returning it means every request goes
+    /// out as `Bearer+agent ` and comes back 403 "Authentication credentials
+    /// were not provided" — while a perfectly good domain sits further down the
+    /// list.
     pub async fn active(&self) -> Result<Arc<LoadedDomain>> {
-        self.domains
+        let selected = self
+            .domains
             .read()
             .await
             .iter()
-            .find(|d| d.cfg.enabled)
+            .find(|d| d.cfg.enabled && !d.cfg.token.is_empty())
             .cloned()
-            .ok_or_else(|| eyre!("no enabled domain configured"))
+            .ok_or_else(|| eyre!("no enabled domain with a token configured"))?;
+        tracing::debug!(domain = %selected.cfg.domain, "selected active domain");
+        Ok(selected)
     }
 
     pub async fn save_domain(&self, cfg: DomainConfig) -> Result<()> {


### PR DESCRIPTION
## Details

### What does this PR change?

Three related changes to how sysd handles domains, all in `cfg/domain.rs`:

1. **`active()` skips domains with no token.** It previously returned the first `enabled` domain regardless of whether it could authenticate.
2. **`active()` prefers an MDM-managed domain** when one is usable, falling back to the first usable domain otherwise.
3. **`load_managed()` removes the managed domain when its config is gone**, which its doc comment ("Loads (or re-enrolls, or removes)…") already promised but never did.

`active()` also now logs which domain it selected.

### Why is this change needed?

`load_managed` adds an `ak-mdm-managed` domain alongside any user-enrolled ones, so a machine routinely has two. `active()` took the first `enabled` entry in `read_dir` order. On a real macOS host `ak-mdm-managed.json` sorts before `mac.json`, and its enrollment had produced no token — so every Platform SSO registration authenticated as `Bearer+agent ` and came back:

```
403 {"detail":"Authentication credentials were not provided."}
```

while a perfectly good domain sat second in the list. Nothing logged which domain had been chosen, so this presented as "PSSO registration is broken" and took a long time to attribute.

Ordering is also mutable at runtime, not just arbitrary: `save_domain` does `retain(…)` then `push(…)`, so re-running `domains join` moves that domain to the **end** of the list — re-enrolling a domain makes it *less* likely to be selected until the next restart.

Preferring the managed domain gives a rule that can be stated in a sentence: MDM policy beats a hand-run `domains join`. The managed enrollment carries the connector and device group the organisation assigned; a manual join may point elsewhere.

The teardown matters because `load_all` reloads every `*.json` whether or not the config that created it still exists. A machine that was managed once keeps a phantom managed domain forever — never refreshed, never revocable by removing the profile, and still competing to be active. Observed on a live host: `ak-mdm-managed.json` persisted for hours after its managed preferences stopped resolving.

### How was this tested?

`cargo check -p ak-sysd`. Verified on macOS 26.6 with both a token-less `ak-mdm-managed` and a working `mac` domain: before, `RegisterDevice` returned 403 "credentials were not provided"; after, sysd selects `mac` and the request authenticates.

### Known limitation

This makes selection deterministic; it does not resolve the underlying split. The storage layer holds N domains and exposes `DomainList`/`DomainEnroll`/`DomainUnenroll`, but nine call sites (`ping`, `auth/apple`, `auth/token`, `auth/interactive`, `session`, `directory`) each take `active()` and ignore the rest — only `device` check-in and `healthcheck_all` fan out. If a machine is deliberately enrolled with two authentik instances, those paths will silently use one of them. Making multi-domain genuinely work means binding a domain to each call site, which is a larger design decision for whoever owns the domain model.

### Linked issues

One of several macOS regressions found alongside the Rust migration (#1262), with #1358 and #1360.

## Checklist

- [ ] The project has been linted, built, and tested (`make all`)
- [ ] The documentation has been updated and formatted (`make docs`)