### PR TITLE
ak-sysd: keep the file fallback unless the keyring token reads back

### DIFF
--- a/ak-sysd/src/cfg/domain.rs
+++ b/ak-sysd/src/cfg/domain.rs
@@ -238,7 +238,36 @@ impl DomainManager {
             )
             .await
         {
-            Ok(_) => on_disk.fallback_token = String::new(),
+            // A write that cannot be read back is no use to us, so confirm the
+            // value is retrievable before dropping the on-disk copy. On macOS
+            // the write succeeds from a launchd daemon but the read fails with
+            // errSecInteractionNotAllowed, because retrieving the item wants an
+            // ACL prompt and there is no UI session to show one. Clearing the
+            // fallback on the strength of the write alone leaves the token
+            // somewhere sysd can never reach, and every subsequent request goes
+            // out as `Bearer+agent ` and comes back 403.
+            Ok(_) => match ak_platform_keyring::store()
+                .get(
+                    &keyring_service(),
+                    &cfg.domain,
+                    ak_platform_keyring::Accessibility::Always,
+                )
+                .await
+            {
+                Ok(stored) if stored == cfg.token => on_disk.fallback_token = String::new(),
+                Ok(_) => {
+                    on_disk.fallback_token = cfg.token.clone();
+                    tracing::warn!(
+                        "keyring returned a different token than was written, keeping file fallback"
+                    );
+                }
+                Err(e) => {
+                    on_disk.fallback_token = cfg.token.clone();
+                    tracing::warn!(
+                        "saved domain token to keyring but could not read it back ({e:?}), keeping file fallback"
+                    );
+                }
+            },
             Err(e) => {
                 on_disk.fallback_token = cfg.token.clone();
                 tracing::warn!(


### PR DESCRIPTION
## Details

### What does this PR change?

`save_domain` cleared `fallback_token` whenever the keyring **write** returned `Ok`. It now also reads the value back, and only drops the on-disk copy if the read succeeds and matches.

### Why is this change needed?

On macOS the write succeeds from a launchd daemon but the read fails with `errSecInteractionNotAllowed` — retrieving the item wants an ACL prompt and a root daemon has no UI session to show one:

```
failed load domain token from keyring, falling back to file:
    Other(User interaction is not allowed. ak-platform-keyring/src/macos.rs:72:47)
```

Because the write looked fine, `fallback_token` was blanked, so `resolve_token` fell back to an empty string. Every request then went out as `Bearer+agent ` and came back:

```
403 {"detail":"Authentication credentials were not provided."}
```

The effect is that any successful `ak-sysd domains join` leaves the device token somewhere sysd can never read, and authentication breaks on the next restart. Observed repeatedly on macOS 26.6; the token had to be written into `domains/<name>.json` by hand each time to recover.

`DomainConfig::fallback_token` is documented as "Only present in the JSON file if the keyring is unavailable" — a keyring that can be written but not read is unavailable for this purpose, so this restores the intended behaviour rather than adding a new one.

### How was this tested?

`cargo check -p ak-sysd`. Verified against a live macOS 26.6 host: `domains join` succeeds, the keychain item is created, and the read-back fails — with this change the token stays in the JSON file and sysd authenticates after a restart instead of 403ing.

### Linked issues

Found alongside two other macOS regressions from the Rust migration (#1262): the PSSO `:authority` rejection and `active()` selecting a token-less domain.

## Checklist

- [ ] The project has been linted, built, and tested (`make all`)
- [ ] The documentation has been updated and formatted (`make docs`)