### PR TITLE
ak-sysd: read managed preferences via CFPreferences, not defaults(1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,8 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "core-foundation",
+ "core-foundation-sys",
  "eyre",
  "hex",
  "httptest",

--- a/ak-sysd/Cargo.toml
+++ b/ak-sysd/Cargo.toml
@@ -52,6 +52,10 @@ signal-hook = "0.4"
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2.186"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.10"
+core-foundation-sys = "0.8"
+
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.8"
 winreg = { version = "0.56", features = ["serialization-serde"] }

--- a/ak-sysd/src/cfg/managed.rs
+++ b/ak-sysd/src/cfg/managed.rs
@@ -9,29 +9,64 @@ pub struct SysdManagedConfig {
 /// package. Returns `Ok(None)` if there is no managed config source on this
 /// platform or no value is currently set (both are normal, not errors).
 #[cfg(target_os = "macos")]
-pub fn load_managed_config() -> Result<Option<SysdManagedConfig>> {
-    // `defaults read` resolves the same preferences domain
-    // (`io.goauthentik.platform`) that Go's CFPreferencesCopyAppValue call
-    // reads from. Shelling out avoids a raw Core Foundation FFI dependency;
-    // if strict merging of the MDM-managed preferences layer (as opposed to
-    // this host's local preferences) turns out to matter, replace this with
-    // a direct CFPreferencesCopyAppValue call instead.
-    let read = |key: &str| -> Option<String> {
-        let out = std::process::Command::new("defaults")
-            .args(["read", "io.goauthentik.platform", key])
-            .output()
-            .ok()?;
-        if !out.status.success() {
+const MANAGED_APP_ID: &str = "io.goauthentik.platform";
+
+/// Reads a single MDM-forced string preference.
+///
+/// `CFPreferencesCopyAppValue` is the API Go used, and it is the only way to
+/// see the managed layer: profile-delivered values live in
+/// `/Library/Managed Preferences/<app-id>.plist`, and `defaults read <app-id>`
+/// does **not** resolve them — it reports "domain does not exist" on a machine
+/// that plainly has the plist. Shelling out therefore made managed enrollment a
+/// silent no-op on every managed Mac.
+///
+/// `CFPreferencesAppValueIsForced` gates on the value actually being managed.
+/// `CopyAppValue` alone returns the *effective* value, which may come from
+/// ordinary user defaults — and this value decides which authentik a root
+/// daemon enrolls against, so anything not delivered by MDM is ignored.
+#[cfg(target_os = "macos")]
+fn managed_string(key: &str) -> Option<String> {
+    use core_foundation::base::TCFType;
+    use core_foundation::string::CFString;
+    use core_foundation_sys::base::{CFGetTypeID, CFRelease};
+    use core_foundation_sys::preferences::{
+        CFPreferencesAppValueIsForced, CFPreferencesCopyAppValue,
+    };
+    use core_foundation_sys::string::CFStringRef;
+
+    let cf_key = CFString::new(key);
+    let cf_app = CFString::new(MANAGED_APP_ID);
+
+    unsafe {
+        if CFPreferencesAppValueIsForced(cf_key.as_concrete_TypeRef(), cf_app.as_concrete_TypeRef())
+            == 0
+        {
             return None;
         }
-        let val = String::from_utf8_lossy(&out.stdout).trim().to_string();
-        if val.is_empty() { None } else { Some(val) }
-    };
 
-    let Some(url) = read("URL") else {
+        let value =
+            CFPreferencesCopyAppValue(cf_key.as_concrete_TypeRef(), cf_app.as_concrete_TypeRef());
+        if value.is_null() {
+            return None;
+        }
+
+        // Copy* returns +1; we own it from here.
+        if CFGetTypeID(value) != CFString::type_id() {
+            CFRelease(value);
+            tracing::warn!(key, "managed preference is not a string, ignoring");
+            return None;
+        }
+        let s = CFString::wrap_under_create_rule(value as CFStringRef).to_string();
+        if s.is_empty() { None } else { Some(s) }
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn load_managed_config() -> Result<Option<SysdManagedConfig>> {
+    let Some(url) = managed_string("URL") else {
         return Ok(None);
     };
-    let Some(registration_token) = read("RegistrationToken") else {
+    let Some(registration_token) = managed_string("RegistrationToken") else {
         return Ok(None);
     };
     Ok(Some(SysdManagedConfig {


### PR DESCRIPTION
## Details

### What does this PR change?

`load_managed_config` on macOS no longer shells out to `defaults read io.goauthentik.platform`. It calls `CFPreferencesCopyAppValue`, gated on `CFPreferencesAppValueIsForced`.

### Why is this change needed?

`defaults read <app-id>` does not resolve the MDM-managed preferences layer. On a host with the profile installed:

```
$ sudo defaults read io.goauthentik.platform URL
Domain io.goauthentik.platform does not exist

$ sudo defaults read "/Library/Managed Preferences/io.goauthentik.platform" URL
https://authentik.connorpeshek.me/
```

So `load_managed_config` returned `None` and `load_managed` bailed on its first line — **MDM-driven enrollment has been a silent no-op on macOS since the migration to Rust**. There is no error; the machine simply never enrolls.

The existing comment anticipated this:

> `defaults read` resolves the same preferences domain that Go's `CFPreferencesCopyAppValue` call reads from. […] if strict merging of the MDM-managed preferences layer (as opposed to this host's local preferences) turns out to matter, replace this with a direct `CFPreferencesCopyAppValue` call instead.

It turns out to matter. `CFPreferencesCopyAppValue` consults the managed layer; `defaults read` by app-id does not.

The `IsForced` guard is deliberate. `CopyAppValue` returns the *effective* value, which can come from ordinary user defaults. This value decides which authentik instance a root daemon enrolls against, so only MDM-delivered values are accepted.

`core-foundation` was already vendored via `ak-platform-keyring`, and `core-foundation-sys` already ships both bindings, so no hand-written FFI is needed.

### How was this tested?

`cargo check -p ak-sysd`. Both functions were exercised against the live managed profile on a macOS 26.6 host via `ctypes`, as `connor` and as `root`:

```
URL                  IsForced=True  value=https://authentik.connorpeshek.me/
RegistrationToken    IsForced=True  value=<60 chars>
```

Both resolve, and both report as forced — where `defaults read` reports the domain does not exist.

### Ordering note

This should land **after** #1359. Once managed enrollment starts working again, machines that also have a user-enrolled domain will have two, and #1359 is what makes the choice between them deterministic (managed wins) and cleans up stale managed domains. Merging this first would turn a silent no-op into a nondeterministic choice of authentik instance.

### Linked issues

One of several macOS regressions found alongside the Rust migration (#1262), with #1358, #1359 and #1360.

## Checklist

- [ ] The project has been linted, built, and tested (`make all`)
- [ ] The documentation has been updated and formatted (`make docs`)