### PR TITLE
ak-platform: fix listen windows DACL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,8 @@ dependencies = [
  "tower",
  "tower-http 0.7.0",
  "tracing",
+ "widestring",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/ak-platform/Cargo.toml
+++ b/ak-platform/Cargo.toml
@@ -51,7 +51,14 @@ libc = "0.2.186"
 
 [target.'cfg(windows)'.dependencies]
 eventlog = "0.4.0"
+# SDDL literals for the named-pipe DACLs in `net::server`; must stay on the same
+# major as the `widestring` re-exported through `interprocess`.
+widestring = "1"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "io-util"] }
 tempfile = { workspace = true }
+
+# `tests/windows_socket_dacl.rs` reads the DACL back off a live named pipe.
+[target.'cfg(windows)'.dev-dependencies]
+windows = { workspace = true }

--- a/ak-platform/src/net/server/mod.rs
+++ b/ak-platform/src/net/server/mod.rs
@@ -7,10 +7,16 @@ use std::{
 };
 
 use interprocess::local_socket::{GenericFilePath, ListenerOptions, tokio::prelude::*};
+#[cfg(windows)]
+use interprocess::os::windows::{
+    local_socket::ListenerOptionsExt, security_descriptor::SecurityDescriptor,
+};
 use ssh_agent_lib::agent::ListeningSocket;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::sync::mpsc;
 use tokio_stream::Stream as AsyncStream;
+#[cfg(windows)]
+use widestring::{U16CStr, u16cstr};
 
 use crate::string::PlatformString;
 
@@ -21,6 +27,24 @@ pub enum SocketPermMode {
     Owner,
     Everyone,
     Admin,
+}
+
+impl SocketPermMode {
+    /// Named pipes carry no file mode, so the Unix permission bits are expressed
+    /// as a DACL instead. `FA` is full access, granted to the pipe's owner (`OW`),
+    /// to Everyone (`WD`), or to built-in Administrators (`BA`) plus SYSTEM (`SY`)
+    /// — the admin case deliberately omits the owner so an unprivileged creator
+    /// cannot reconnect to its own socket.
+    #[cfg(windows)]
+    fn security_descriptor(&self) -> Result<SecurityDescriptor> {
+        let sddl: &U16CStr = match self {
+            Self::Owner => u16cstr!("D:(A;;FA;;;OW)"),
+            Self::Everyone => u16cstr!("D:(A;;FA;;;WD)"),
+            Self::Admin => u16cstr!("D:(A;;FA;;;BA)(A;;FA;;;SY)"),
+        };
+        SecurityDescriptor::deserialize(sddl)
+            .map_err(|e| eyre::eyre!("failed to build socket security descriptor: {e}"))
+    }
 }
 
 pub struct ConnectedLocalStream(LocalSocketStream);
@@ -108,18 +132,21 @@ pub async fn listen(path: PlatformString, perm: SocketPermMode) -> Result<Listen
         SocketPermMode::Everyone => 0o666,
         SocketPermMode::Admin => 0o660,
     };
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     let _ = perm;
+
+    let options = ListenerOptions::new().name(name).try_overwrite(true);
+    // Built before the umask swap below so a failure here can't return early
+    // with the process umask still restricted.
+    #[cfg(windows)]
+    let options = options.security_descriptor(perm.security_descriptor()?);
 
     // Restrict umask to close the TOCTOU window where the socket file briefly
     // exists with permissive default permissions before the final chmod runs.
     #[cfg(unix)]
     let old_umask = unsafe { libc::umask(0o777 & !mode) };
 
-    let create_result = ListenerOptions::new()
-        .name(name)
-        .try_overwrite(true)
-        .create_tokio();
+    let create_result = options.create_tokio();
 
     #[cfg(unix)]
     unsafe {
@@ -202,6 +229,18 @@ mod tests {
         let _listener = listen(ps(path), SocketPermMode::Everyone).await.unwrap();
         let mode = std::fs::metadata(path).unwrap().mode() & 0o777;
         assert_eq!(mode, 0o666);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn perm_modes_have_valid_sddl() {
+        for perm in [
+            SocketPermMode::Owner,
+            SocketPermMode::Everyone,
+            SocketPermMode::Admin,
+        ] {
+            perm.security_descriptor().unwrap();
+        }
     }
 
     #[cfg(windows)]

--- a/ak-platform/tests/windows_socket_dacl.rs
+++ b/ak-platform/tests/windows_socket_dacl.rs
@@ -1,0 +1,182 @@
+//! Integration coverage for the DACLs `net::server::listen` attaches to Windows
+//! named pipes.
+//!
+//! These were dropped in the Go -> Rust port, so the failure mode worth guarding
+//! against is "no descriptor applied at all" — a pipe created with the default
+//! descriptor still works locally, it just silently grants the wrong set of
+//! callers. Each test therefore reads the DACL back off the live pipe and
+//! compares it to the one its `SocketPermMode` is supposed to produce.
+
+#![cfg(windows)]
+
+use std::ffi::c_void;
+
+use ak_platform::net::server::SocketPermMode;
+use ak_platform::net::{client, server};
+use ak_platform::string::PlatformString;
+use windows::Win32::Foundation::{ERROR_SUCCESS, HLOCAL, LocalFree};
+use windows::Win32::Security::Authorization::{
+    ConvertSecurityDescriptorToStringSecurityDescriptorW,
+    ConvertStringSecurityDescriptorToSecurityDescriptorW, GetNamedSecurityInfoW, SDDL_REVISION_1,
+    SE_FILE_OBJECT,
+};
+use windows::Win32::Security::{
+    CheckTokenMembership, CreateWellKnownSid, DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR,
+    PSID, SECURITY_MAX_SID_SIZE, WinBuiltinAdministratorsSid,
+};
+use windows::core::{BOOL, HSTRING, PWSTR};
+
+/// A DACL, always held in the spelling Windows itself produces.
+///
+/// The same access mask has several valid SDDL spellings (`FA` vs `0x1f01ff`,
+/// differing ACE order), so both the expected and the observed descriptor are
+/// run through `ConvertSecurityDescriptorToStringSecurityDescriptorW` before
+/// being compared — otherwise a passing test could fail on formatting alone.
+#[derive(Debug, PartialEq, Eq)]
+struct Dacl(String);
+
+impl Dacl {
+    /// Reads back what Windows actually stored on the pipe at `path`.
+    fn of_pipe(path: &str) -> Self {
+        let mut psd = PSECURITY_DESCRIPTOR::default();
+        let status = unsafe {
+            GetNamedSecurityInfoW(
+                &HSTRING::from(path),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION,
+                None,
+                None,
+                None,
+                None,
+                &mut psd,
+            )
+        };
+        assert_eq!(status, ERROR_SUCCESS, "could not read the DACL of {path}");
+
+        let dacl = Self::serialize(psd);
+        unsafe { LocalFree(Some(HLOCAL(psd.0))) };
+        dacl
+    }
+
+    /// The DACL described by an SDDL literal.
+    fn of_sddl(sddl: &str) -> Self {
+        let mut psd = PSECURITY_DESCRIPTOR::default();
+        unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                &HSTRING::from(sddl),
+                SDDL_REVISION_1,
+                &mut psd,
+                None,
+            )
+        }
+        .unwrap_or_else(|e| panic!("{sddl} is not valid SDDL: {e}"));
+
+        let dacl = Self::serialize(psd);
+        unsafe { LocalFree(Some(HLOCAL(psd.0))) };
+        dacl
+    }
+
+    fn serialize(psd: PSECURITY_DESCRIPTOR) -> Self {
+        let mut sddl = PWSTR::null();
+        unsafe {
+            ConvertSecurityDescriptorToStringSecurityDescriptorW(
+                psd,
+                SDDL_REVISION_1,
+                DACL_SECURITY_INFORMATION,
+                &mut sddl,
+                None,
+            )
+        }
+        .unwrap();
+
+        let owned = unsafe { sddl.to_string() }.unwrap();
+        unsafe { LocalFree(Some(HLOCAL(sddl.0 as *mut c_void))) };
+        Self(owned)
+    }
+}
+
+/// Whether this process's token would pass an access check against the built-in
+/// Administrators SID. On a UAC-split token this stays false until the process
+/// is actually elevated, which is exactly the line `SocketPermMode::Admin` draws.
+fn is_administrator() -> bool {
+    let mut sid = [0u8; SECURITY_MAX_SID_SIZE as usize];
+    let mut len = sid.len() as u32;
+    let psid = PSID(sid.as_mut_ptr() as *mut c_void);
+    unsafe { CreateWellKnownSid(WinBuiltinAdministratorsSid, None, Some(psid), &mut len) }.unwrap();
+
+    let mut is_member = BOOL::default();
+    unsafe { CheckTokenMembership(None, psid, &mut is_member) }.unwrap();
+    is_member.as_bool()
+}
+
+#[tokio::test]
+async fn owner_mode_grants_the_owner_only() {
+    let path = r"\\.\pipe\ak-test-dacl-owner";
+    let _listener = server::listen(
+        PlatformString::new_with_default(path),
+        SocketPermMode::Owner,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(Dacl::of_pipe(path), Dacl::of_sddl("D:(A;;FA;;;OW)"));
+}
+
+#[tokio::test]
+async fn everyone_mode_grants_world() {
+    let path = r"\\.\pipe\ak-test-dacl-everyone";
+    let _listener = server::listen(
+        PlatformString::new_with_default(path),
+        SocketPermMode::Everyone,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(Dacl::of_pipe(path), Dacl::of_sddl("D:(A;;FA;;;WD)"));
+}
+
+#[tokio::test]
+async fn admin_mode_grants_administrators_and_system_only() {
+    let path = r"\\.\pipe\ak-test-dacl-admin";
+    let _listener = server::listen(
+        PlatformString::new_with_default(path),
+        SocketPermMode::Admin,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        Dacl::of_pipe(path),
+        Dacl::of_sddl("D:(A;;FA;;;BA)(A;;FA;;;SY)")
+    );
+}
+
+#[tokio::test]
+async fn everyone_mode_accepts_a_client() {
+    let path = PlatformString::new_with_default(r"\\.\pipe\ak-test-dacl-everyone-connect");
+    let _listener = server::listen(path.clone(), SocketPermMode::Everyone)
+        .await
+        .unwrap();
+
+    client::connect(path).await.unwrap();
+}
+
+/// The descriptor is only meaningful if it actually turns callers away, so check
+/// the access check too — but only when the test process is outside the
+/// Administrators group, since an elevated runner is legitimately allowed in.
+#[tokio::test]
+async fn admin_mode_rejects_an_unelevated_client() {
+    if is_administrator() {
+        return;
+    }
+
+    let path = PlatformString::new_with_default(r"\\.\pipe\ak-test-dacl-admin-connect");
+    let _listener = server::listen(path.clone(), SocketPermMode::Admin)
+        .await
+        .unwrap();
+
+    let Err(err) = client::connect(path).await else {
+        panic!("a non-administrator connected to an admin-only pipe");
+    };
+    assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+}


### PR DESCRIPTION
this was accidentally lost during the rust migration, now with tests